### PR TITLE
Bump nostr-strfry to strfry 1.1.0

### DIFF
--- a/charts/nostr-strfry/Chart.yaml
+++ b/charts/nostr-strfry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nostr-strfry
 description: A Helm chart for deploying a Nostr strfry relay
 type: application
-version: 1.1.2
-appVersion: "1.0.4"
+version: 1.2.0
+appVersion: "1.1.0"
 home: https://nostr.com/
 icon: https://user-images.githubusercontent.com/99301796/219900773-d6d02038-e2a0-4334-9f28-c14d40ab6fe7.png
 maintainers:
@@ -25,4 +25,4 @@ annotations:
       url: https://github.com/dockur/strfry
   artifacthub.io/images: |
     - name: strfry
-      image: dockurr/strfry:1.0.4
+      image: dockurr/strfry:1.1.0

--- a/charts/nostr-strfry/README.md
+++ b/charts/nostr-strfry/README.md
@@ -1,6 +1,6 @@
 # nostr-strfry
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for deploying a Nostr strfry relay
 
@@ -49,25 +49,38 @@ The following table lists the configurable parameters for the nostr-strfry chart
 | config.events.rejectEphemeralEventsOlderThanSeconds | int | `60` | Ephemeral events older than this (in seconds) will be rejected |
 | config.events.rejectEventsNewerThanSeconds | int | `900` | Events newer than this (in seconds) will be rejected |
 | config.events.rejectEventsOlderThanSeconds | string | `"94608000"` | Events older than this (in seconds) will be rejected |
+| config.relay.auth.enabled | bool | `false` | Enable NIP-42 authentication. When true, `serviceUrl` must be set. |
+| config.relay.auth.serviceUrl | string | `""` | External relay URL required for NIP-42 validation (e.g. wss://relay.example.com) |
 | config.relay.autoPingSeconds | int | `55` | Websocket-level PING message frequency (seconds) |
 | config.relay.bind | string | `"0.0.0.0"` | Interface to listen on (Use 0.0.0.0 for k3s) |
 | config.relay.compression.enabled | bool | `true` | Enable permessage-deflate compression if supported by client |
 | config.relay.compression.slidingWindow | bool | `true` | Maintain a sliding window buffer for each connection |
 | config.relay.enableTcpKeepalive | bool | `false` | Enable TCP keep-alive to detect dropped connections |
+| config.relay.filterValidation.allowedKinds | string | `""` | Comma-separated list of allowed kinds (empty = all) |
+| config.relay.filterValidation.enabled | bool | `false` | Enable REQ filter validation |
+| config.relay.filterValidation.maxFiltersPerReq | int | `3` | Maximum number of filters allowed per REQ |
+| config.relay.filterValidation.maxKindsPerFilter | int | `3` | Maximum number of kinds allowed per filter |
+| config.relay.filterValidation.minFiltersPerReq | int | `1` | Minimum number of filters required per REQ |
+| config.relay.filterValidation.requireAuthorOrTag | bool | `false` | Require filters to contain an author or tag constraint |
+| config.relay.info.banner | string | `""` | NIP-11: Banner image URL |
 | config.relay.info.contact | string | `""` | NIP-11: Alternative administrative contact |
 | config.relay.info.description | string | `"This is a strfry instance."` | NIP-11: Detailed information about relay |
 | config.relay.info.icon | string | `""` | NIP-11: URL pointing to an image to be used as an icon for the relay |
 | config.relay.info.name | string | `"strfry default"` | NIP-11: Name of this server (< 30 characters) |
 | config.relay.info.nips | string | `""` | List of supported NIPs as JSON array, or empty string to use default |
+| config.relay.info.privacy | string | `""` | NIP-11: Privacy policy URL |
 | config.relay.info.pubkey | string | `""` | NIP-11: Administrative nostr pubkey, for contact purposes |
+| config.relay.info.self | string | `""` | NIP-11: Relay's own pubkey (npub or hex format) |
+| config.relay.info.terms | string | `""` | NIP-11: Terms of service URL |
 | config.relay.logging.dbScanPerf | bool | `false` | Log performance metrics for initial REQ database scans |
 | config.relay.logging.dumpInAll | bool | `false` | Dump all incoming messages |
 | config.relay.logging.dumpInEvents | bool | `false` | Dump all incoming EVENT messages |
 | config.relay.logging.dumpInReqs | bool | `false` | Dump all incoming REQ/CLOSE messages |
 | config.relay.logging.invalidEvents | bool | `true` | Log reason for invalid event rejection |
 | config.relay.maxFilterLimit | int | `500` | Maximum records that can be returned per filter |
+| config.relay.maxFilterLimitCount | string | `"1000000"` | Maximum records that can be returned per filter for NIP-45 COUNT (0 = disable) |
 | config.relay.maxReqFilterSize | int | `200` | Maximum number of filters allowed in a REQ |
-| config.relay.maxSubsPerConnection | int | `20` | Maximum number of subscriptions a connection can have open |
+| config.relay.maxSubsPerConnection | int | `200` | Maximum number of subscriptions a connection can have open |
 | config.relay.maxWebsocketPayloadSize | string | `"131072"` | Maximum accepted incoming websocket frame size (bytes) |
 | config.relay.negentropy.enabled | bool | `true` | Support negentropy protocol messages |
 | config.relay.negentropy.maxSyncEvents | string | `"1000000"` | Maximum records that sync will process before returning an error |
@@ -80,6 +93,7 @@ The following table lists the configurable parameters for the nostr-strfry chart
 | config.relay.queryTimesliceBudgetMicroseconds | string | `"10000"` | Uninterrupted CPU time for a REQ query during DB scan (microseconds) |
 | config.relay.realIpHeader | string | `""` | HTTP header that contains the client's real IP, before reverse proxying (must be all lower-case) |
 | config.relay.writePolicy.plugin | string | `""` | Path to an executable script that implements the writePolicy plugin logic |
+| config.relay.writePolicy.timeoutSeconds | int | `10` | Timeout in seconds for the writePolicy plugin response |
 | fullnameOverride | string | `""` | String to fully override nostr-relay.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Nostr relay Docker image pull policy |
 | image.repository | string | `"dockurr/strfry"` | Nostr strfry Docker image repository |

--- a/charts/nostr-strfry/templates/configmap.yaml
+++ b/charts/nostr-strfry/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.config.relay.auth.enabled (not .Values.config.relay.auth.serviceUrl) -}}
+{{- fail "config.relay.auth.enabled is true but config.relay.auth.serviceUrl is empty. NIP-42 challenge validation requires an external relay URL (e.g. wss://relay.example.com)." -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -74,6 +77,18 @@ data:
 
         # List of supported lists as JSON array, or empty string to use default. Example: "[1,2]"
         nips = {{ .Values.config.relay.info.nips | quote }}
+
+        # NIP-11: Relay's own pubkey (npub or hex format)
+        self = {{ .Values.config.relay.info.self | quote }}
+
+        # NIP-11: Banner image URL
+        banner = {{ .Values.config.relay.info.banner | quote }}
+
+        # NIP-11: Privacy policy URL
+        privacy = {{ .Values.config.relay.info.privacy | quote }}
+
+        # NIP-11: Terms of service URL
+        terms = {{ .Values.config.relay.info.terms | quote }}
       }
 
       # Maximum accepted incoming websocket frame size (should be larger than max event) (restart required)
@@ -94,12 +109,18 @@ data:
       # Maximum records that can be returned per filter
       maxFilterLimit = {{ .Values.config.relay.maxFilterLimit }}
 
+      # Maximum records that can be returned per filter for NIP-45 COUNT (0 = disable)
+      maxFilterLimitCount = {{ .Values.config.relay.maxFilterLimitCount }}
+
       # Maximum number of subscriptions (concurrent REQs) a connection can have open at any time
       maxSubsPerConnection = {{ .Values.config.relay.maxSubsPerConnection }}
 
       writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic
         plugin = {{ .Values.config.relay.writePolicy.plugin | quote }}
+
+        # Timeout in seconds for the writePolicy plugin response
+        timeoutSeconds = {{ .Values.config.relay.writePolicy.timeoutSeconds }}
       }
 
       compression {
@@ -147,6 +168,34 @@ data:
 
         # Maximum records that sync will process before returning an error
         maxSyncEvents = {{ .Values.config.relay.negentropy.maxSyncEvents }}
+      }
+
+      auth {
+        # Enable NIP-42 authentication
+        enabled = {{ .Values.config.relay.auth.enabled }}
+
+        # External relay URL required for NIP-42 validation
+        serviceUrl = {{ .Values.config.relay.auth.serviceUrl | quote }}
+      }
+
+      filterValidation {
+        # Enable REQ filter validation
+        enabled = {{ .Values.config.relay.filterValidation.enabled }}
+
+        # Maximum number of filters allowed per REQ
+        maxFiltersPerReq = {{ .Values.config.relay.filterValidation.maxFiltersPerReq }}
+
+        # Minimum number of filters required per REQ
+        minFiltersPerReq = {{ .Values.config.relay.filterValidation.minFiltersPerReq }}
+
+        # Maximum number of kinds allowed per filter
+        maxKindsPerFilter = {{ .Values.config.relay.filterValidation.maxKindsPerFilter }}
+
+        # Comma-separated list of allowed kinds (empty = all)
+        allowedKinds = {{ .Values.config.relay.filterValidation.allowedKinds | quote }}
+
+        # Require filters to contain an author or tag constraint
+        requireAuthorOrTag = {{ .Values.config.relay.filterValidation.requireAuthorOrTag }}
       }
     }
 {{ if .Values.nip05.enabled }}

--- a/charts/nostr-strfry/values.yaml
+++ b/charts/nostr-strfry/values.yaml
@@ -165,6 +165,14 @@ config:
       icon: ""
       # -- List of supported NIPs as JSON array, or empty string to use default
       nips: ""
+      # -- NIP-11: Relay's own pubkey (npub or hex format)
+      self: ""
+      # -- NIP-11: Banner image URL
+      banner: ""
+      # -- NIP-11: Privacy policy URL
+      privacy: ""
+      # -- NIP-11: Terms of service URL
+      terms: ""
     # -- Maximum accepted incoming websocket frame size (bytes)
     maxWebsocketPayloadSize: "131072"
     # -- Maximum number of filters allowed in a REQ
@@ -178,10 +186,14 @@ config:
     # -- Maximum records that can be returned per filter
     maxFilterLimit: 500
     # -- Maximum number of subscriptions a connection can have open
-    maxSubsPerConnection: 20
+    maxSubsPerConnection: 200
+    # -- Maximum records that can be returned per filter for NIP-45 COUNT (0 = disable)
+    maxFilterLimitCount: "1000000"
     writePolicy:
       # -- Path to an executable script that implements the writePolicy plugin logic
       plugin: ""
+      # -- Timeout in seconds for the writePolicy plugin response
+      timeoutSeconds: 10
     compression:
       # -- Enable permessage-deflate compression if supported by client
       enabled: true
@@ -212,3 +224,21 @@ config:
       enabled: true
       # -- Maximum records that sync will process before returning an error
       maxSyncEvents: "1000000"
+    auth:
+      # -- Enable NIP-42 authentication. When true, `serviceUrl` must be set.
+      enabled: false
+      # -- External relay URL required for NIP-42 validation (e.g. wss://relay.example.com)
+      serviceUrl: ""
+    filterValidation:
+      # -- Enable REQ filter validation
+      enabled: false
+      # -- Maximum number of filters allowed per REQ
+      maxFiltersPerReq: 3
+      # -- Minimum number of filters required per REQ
+      minFiltersPerReq: 1
+      # -- Maximum number of kinds allowed per filter
+      maxKindsPerFilter: 3
+      # -- Comma-separated list of allowed kinds (empty = all)
+      allowedKinds: ""
+      # -- Require filters to contain an author or tag constraint
+      requireAuthorOrTag: false


### PR DESCRIPTION
## Summary
- Bumps `nostr-strfry` chart to `1.2.0` and `appVersion` to `1.1.0` (dockurr/strfry:1.1.0).
- Surfaces new strfry 1.1.0 config knobs in `values.yaml` and the rendered configmap:
  - NIP-11 metadata: `self`, `banner`, `privacy`, `terms`
  - `maxFilterLimitCount` (NIP-45 COUNT cap)
  - `writePolicy.timeoutSeconds`
  - `filterValidation` block (REQ shape limits)
  - `auth` block (NIP-42)
- Syncs `maxSubsPerConnection` default with upstream `strfry.conf` (`20` -> `200`). No-op for users who set it explicitly.

## NIP-42 auth: safe-by-default
Upstream comments NIP-42 `serviceUrl` as **required** for challenge validation. To avoid surprising existing deployments on upgrade:
- `config.relay.auth.enabled` defaults to `false`.
- When set to `true`, `templates/configmap.yaml` calls `fail` if `serviceUrl` is empty, so misconfiguration is caught at `helm install/template` time with an actionable message instead of a crashlooping pod.

## Test plan
- [x] `helm lint charts/nostr-strfry`
- [x] `helm template` with default values renders cleanly
- [x] `helm template` with `auth.enabled=true` and empty `serviceUrl` fails with the guard message
- [x] `helm template` with `auth.enabled=true` and `serviceUrl=wss://...` renders cleanly
- [x] `pre-commit run helm-docs` — README regenerated and matches
- [ ] CI: chart-testing lint + KinD install

🤖 Generated with [Claude Code](https://claude.com/claude-code)