### PR TITLE
ci: bump actions to Node 24 versions and unblock non-chart PRs

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
     if: ${{ needs.changes.outputs.charts == 'true' && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -68,7 +68,7 @@ jobs:
         with:
           version: v3.17.0
 
-      - uses: actions/setup-python@v5.3.0
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.x'
           check-latest: true
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'charts/**'
   pull_request:
     branches:
       - main
-    paths:
-      - 'charts/**'
 
 permissions:
   contents: read
@@ -24,6 +20,7 @@ jobs:
     if: github.repository == 'kriegalex/k8s-charts'
     outputs:
       charts: ${{ steps.filter.outputs.charts }}
+      workflows: ${{ steps.filter.outputs.workflows }}
 
     steps:
       - name: Checkout
@@ -51,11 +48,13 @@ jobs:
               - 'charts/*/Chart.yaml'
               - 'charts/*/values.yaml'
               - 'charts/*/templates/**'
+            workflows:
+              - '.github/workflows/**'
 
   lint-test:
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.charts == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -63,33 +62,45 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Lint workflows (actionlint)
+        if: ${{ needs.changes.outputs.workflows == 'true' }}
+        run: docker run --rm -v "${PWD}:/repo" --workdir /repo rhysd/actionlint:1.7.7 -color
+
       - name: Set up Helm
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         uses: azure/setup-helm@v4.2.0
         with:
           version: v3.17.0
 
-      - uses: actions/setup-python@v6.2.0
+      - if: ${{ needs.changes.outputs.charts == 'true' }}
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.x'
           check-latest: true
 
       - name: Set up chart-testing
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         uses: helm/chart-testing-action@v2.8.0
 
       - name: Add Helm repositories
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         run: |
           helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
 
       - name: Run chart-testing (list-changed)
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         run: ct list-changed --target-branch main
 
       - name: Run chart-testing (lint)
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         run: ct lint --target-branch main 2>&1
 
       - name: Create kind cluster
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         uses: helm/kind-action@v1.12.0
 
       - name: Run chart-testing (install)
+        if: ${{ needs.changes.outputs.charts == 'true' }}
         run: ct install --config ct-install-skip.yaml 2>&1
 
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
           ./ah lint || exit 1
           rm -f ./ah ./ah_1.20.0_linux_amd64.tar.gz
 
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@v4.0.1
         id: filter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Two related CI fixes bundled because neither merges without the other.

### Action version bumps (Node 24)
- `actions/checkout@v4` → `@v6` (3 occurrences)
- `actions/setup-python@v5.3.0` → `@v6.2.0`
- `dorny/paths-filter@v3.0.2` → `@v4.0.1`

Silences the Node.js 20 deprecation warnings GitHub started emitting on workflow runs.

### Unblock non-chart PRs
Branch protection requires the `lint-test` status on `main`, but `release.yaml` had a top-level `paths: charts/**` filter — so on PRs that don't touch `charts/**`, the workflow never triggered and the required check stayed pending forever (this PR is the example).

Fix:
- Drop the top-level `paths:` filter so `lint-test` always runs on PRs.
- Per-step `if:` gates keep the heavy chart-testing steps (helm setup, ct lint, KinD install) running only when `charts/**` changes — no extra cost for non-chart PRs.
- Add an `actionlint` step that runs when `.github/workflows/**` changes, so workflow-only PRs get real validation instead of a no-op pass.

`actions/upload-artifact@v4` is still pulled in transitively by `helm/chart-releaser-action@v1.7.0` (latest release, Jan 2025). No upstream fix yet; GitHub auto-flips JS actions to Node 24 in June 2026 anyway.

## Test plan
- [x] CI green on this PR — `lint-test` should run, skip the chart-testing steps, run `actionlint` on the workflow changes
- [ ] Subsequent chart PRs should still run the full `ct lint` + `ct install` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)