### PR TITLE
qbittorrent: add qbittorrentConf init container (chart 2.1.0)

### DIFF
--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying a QBittorrent client that uses a wiregua
 home: https://www.qbittorrent.org/
 icon: https://cloud.githubusercontent.com/assets/14862437/23586868/89ef2922-01c4-11e7-869c-52aafcece17f.png
 type: application
-version: 2.0.1
+version: 2.1.0
 appVersion: "legacy-4.3.9"  # legacy stable version
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -1,6 +1,6 @@
 # QBittorrent Chart
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: legacy-4.3.9](https://img.shields.io/badge/AppVersion-legacy--4.3.9-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: legacy-4.3.9](https://img.shields.io/badge/AppVersion-legacy--4.3.9-informational?style=flat-square)
 
 A Helm chart for deploying a QBittorrent client that uses a wireguard VPN tunnel.
 
@@ -262,6 +262,95 @@ vpn:
 
 ⚠️ **Warning:** Private keys will be visible in your values files and Helm release history.
 
+## qBittorrent.conf — pinning settings via Helm
+
+When `qbittorrentConf.enabled=true`, the chart deploys an init container that
+upserts a chosen set of `qBittorrent.conf` keys into
+`/config/qBittorrent/qBittorrent.conf` on every pod start. Only the keys you
+list are touched; everything else (including settings you change later via
+the WebUI) is preserved across restarts.
+
+The default entries target the libtorrent v2.x memory-mapped-IO behaviour
+([context](https://github.com/arvidn/libtorrent/issues/7551)), which causes
+runaway page-cache usage in containers:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\DiskIOType: 3            # 0=Default, 1=MMap, 2=Posix, 3=SimplePreadPwrite
+      Session\MemoryWorkingSetLimit: 4096   # MiB
+      Session\UseOSCache: false
+```
+
+### Discovering the keys you want to pin
+
+Top-level YAML keys map to `[Section]` headers; second-level keys map to the
+INI keys *as they appear in the file*, including Qt's backslash group
+separator (e.g. `Session\Port`). The simplest discovery flow:
+
+1. Configure qBittorrent the way you want via the WebUI.
+2. `kubectl exec` into the pod and `cat /config/qBittorrent/qBittorrent.conf`.
+3. Copy the lines you care about into `qbittorrentConf.entries`, mirroring
+   their section.
+
+### Worked examples
+
+Pin connection limits and a fixed listen port:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\Port: 6881
+      Session\MaxActiveDownloads: 5
+      Session\MaxActiveUploads: 10
+      Session\MaxActiveTorrents: 15
+      Session\GlobalMaxRatio: 2.0
+```
+
+Lock the WebUI port and the default save path:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    Preferences:
+      WebUI\Port: 8080
+      Downloads\SavePath: /data/downloads/
+      Downloads\TempPath: /data/incomplete/
+```
+
+Combine the libtorrent-v2 mitigations with custom rate limits:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\DiskIOType: 3
+      Session\MemoryWorkingSetLimit: 4096
+      Session\UseOSCache: false
+      Session\GlobalDLSpeedLimit: 0
+      Session\GlobalUPSpeedLimit: 5242880   # bytes/s
+```
+
+### Caveats
+
+- **Set-only.** You can override or add keys; you cannot delete a key
+  through this mechanism. Remove a pinned key from `entries` and wipe the
+  line by hand once if you want it gone.
+- **Single-line values only.** Values are passed through a tab-delimited
+  pipe; no qBittorrent value is multi-line, but be aware if you extend it.
+- **YAML quoting.** A single `\` in a YAML scalar is literal, so
+  `Session\DiskIOType:` works bare. If a future key ever contained `\\` or
+  `\n`, wrap the key in single quotes.
+- **Order isn't preserved across keys you didn't list** — qBittorrent
+  doesn't depend on it, but expect new keys to be appended to their
+  section.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -305,6 +394,9 @@ vpn:
 | persistence.data.accessMode | string | `"ReadWriteOnce"` | Access mode for the data PVC |
 | persistence.data.enabled | bool | `false` | Enable persistent storage for downloads |
 | persistence.data.size | string | `"500Gi"` | Size of the data PVC |
+| qbittorrentConf.enabled | bool | `false` | Enable the qBittorrent.conf init container |
+| qbittorrentConf.entries | object | `{"BitTorrent":{"Session\\DiskIOType":3,"Session\\MemoryWorkingSetLimit":4096,"Session\\UseOSCache":false}}` | INI sections and keys to upsert. Use Qt-style sub-keys with backslashes (e.g. `Session\DiskIOType`). Values are written verbatim — keep them as plain strings/integers/booleans. |
+| qbittorrentConf.image | object | `{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.36"}` | Image used by the seeding init container. Needs `awk` and `sh`. |
 | replicaCount | int | `1` | Number of replicas to be deployed |
 | resources | object | {} | Resource requests and limits for the qBittorrent container @example resources:   limits:     cpu: 100m     memory: 128Mi   requests:     cpu: 100m     memory: 128Mi |
 | service.port | int | `8080` | Port for the qBittorrent WebUI |

--- a/charts/qbittorrent/README.md.gotmpl
+++ b/charts/qbittorrent/README.md.gotmpl
@@ -262,6 +262,95 @@ vpn:
 
 ⚠️ **Warning:** Private keys will be visible in your values files and Helm release history.
 
+## qBittorrent.conf — pinning settings via Helm
+
+When `qbittorrentConf.enabled=true`, the chart deploys an init container that
+upserts a chosen set of `qBittorrent.conf` keys into
+`/config/qBittorrent/qBittorrent.conf` on every pod start. Only the keys you
+list are touched; everything else (including settings you change later via
+the WebUI) is preserved across restarts.
+
+The default entries target the libtorrent v2.x memory-mapped-IO behaviour
+([context](https://github.com/arvidn/libtorrent/issues/7551)), which causes
+runaway page-cache usage in containers:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\DiskIOType: 3            # 0=Default, 1=MMap, 2=Posix, 3=SimplePreadPwrite
+      Session\MemoryWorkingSetLimit: 4096   # MiB
+      Session\UseOSCache: false
+```
+
+### Discovering the keys you want to pin
+
+Top-level YAML keys map to `[Section]` headers; second-level keys map to the
+INI keys *as they appear in the file*, including Qt's backslash group
+separator (e.g. `Session\Port`). The simplest discovery flow:
+
+1. Configure qBittorrent the way you want via the WebUI.
+2. `kubectl exec` into the pod and `cat /config/qBittorrent/qBittorrent.conf`.
+3. Copy the lines you care about into `qbittorrentConf.entries`, mirroring
+   their section.
+
+### Worked examples
+
+Pin connection limits and a fixed listen port:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\Port: 6881
+      Session\MaxActiveDownloads: 5
+      Session\MaxActiveUploads: 10
+      Session\MaxActiveTorrents: 15
+      Session\GlobalMaxRatio: 2.0
+```
+
+Lock the WebUI port and the default save path:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    Preferences:
+      WebUI\Port: 8080
+      Downloads\SavePath: /data/downloads/
+      Downloads\TempPath: /data/incomplete/
+```
+
+Combine the libtorrent-v2 mitigations with custom rate limits:
+
+```yaml
+qbittorrentConf:
+  enabled: true
+  entries:
+    BitTorrent:
+      Session\DiskIOType: 3
+      Session\MemoryWorkingSetLimit: 4096
+      Session\UseOSCache: false
+      Session\GlobalDLSpeedLimit: 0
+      Session\GlobalUPSpeedLimit: 5242880   # bytes/s
+```
+
+### Caveats
+
+- **Set-only.** You can override or add keys; you cannot delete a key
+  through this mechanism. Remove a pinned key from `entries` and wipe the
+  line by hand once if you want it gone.
+- **Single-line values only.** Values are passed through a tab-delimited
+  pipe; no qBittorrent value is multi-line, but be aware if you extend it.
+- **YAML quoting.** A single `\` in a YAML scalar is literal, so
+  `Session\DiskIOType:` works bare. If a future key ever contained `\\` or
+  `\n`, wrap the key in single quotes.
+- **Order isn't preserved across keys you didn't list** — qBittorrent
+  doesn't depend on it, but expect new keys to be appended to their
+  section.
+
 ## Values
 
 {{ template "chart.valuesTable" . }}

--- a/charts/qbittorrent/templates/deployment.yaml
+++ b/charts/qbittorrent/templates/deployment.yaml
@@ -33,8 +33,11 @@ spec:
           - name: net.ipv6.conf.all.disable_ipv6
             value: "1"
       {{- end }}
-      {{- if and .Values.vpn.wireguard.enabled (or .Values.vpn.wireguard.existingSecret .Values.vpn.wireguard.existingConfigMap .Values.vpn.wireguard.config) }}
+      {{- $wgInit := and .Values.vpn.wireguard.enabled (or .Values.vpn.wireguard.existingSecret .Values.vpn.wireguard.existingConfigMap .Values.vpn.wireguard.config) }}
+      {{- $confInit := .Values.qbittorrentConf.enabled }}
+      {{- if or $wgInit $confInit }}
       initContainers:
+        {{- if $wgInit }}
         - name: copy-config
           image: busybox:1.28
           volumeMounts:
@@ -48,6 +51,18 @@ spec:
               set -ex;
               mkdir -p /config/wireguard/;
               cp /src-config/wg0.conf /config/wireguard/wg0.conf;
+        {{- end }}
+        {{- if $confInit }}
+        - name: seed-qbittorrent-conf
+          image: "{{ .Values.qbittorrentConf.image.repository }}:{{ .Values.qbittorrentConf.image.tag }}"
+          imagePullPolicy: {{ .Values.qbittorrentConf.image.pullPolicy }}
+          command: ["/bin/sh", "/seed/upsert.sh"]
+          volumeMounts:
+            - name: qbittorrent-conf-seed
+              mountPath: /seed
+            - name: qbittorrent-config
+              mountPath: /config
+        {{- end }}
       {{- end }}
       containers:
         - name: qbittorrent
@@ -70,6 +85,12 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
 
       volumes:
+        {{- if .Values.qbittorrentConf.enabled }}
+        - name: qbittorrent-conf-seed
+          configMap:
+            name: {{ include "qbittorrent.fullname" . }}-conf
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.vpn.wireguard.enabled }}
         {{- if or .Values.vpn.wireguard.existingSecret .Values.vpn.wireguard.existingConfigMap .Values.vpn.wireguard.config }}
         - name: wg-config

--- a/charts/qbittorrent/templates/qbittorrent-conf.yaml
+++ b/charts/qbittorrent/templates/qbittorrent-conf.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.qbittorrentConf.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "qbittorrent.fullname" . }}-conf
+  labels:
+    app.kubernetes.io/name: {{ include "qbittorrent.name" . }}
+    helm.sh/chart: {{ include "qbittorrent.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  # Newline-separated "Section\tKey\tValue" tuples consumed by the init container.
+  # Tab-delimited so values may contain '=' or spaces without ambiguity.
+  entries.tsv: |
+    {{- range $section, $kv := .Values.qbittorrentConf.entries }}
+    {{- range $key, $val := $kv }}
+    {{ $section }}	{{ $key }}	{{ $val }}
+    {{- end }}
+    {{- end }}
+  upsert.sh: |
+    #!/bin/sh
+    # Upsert each (section,key,value) tuple into qBittorrent.conf.
+    # Idempotent: replaces a line "key=*" inside [section] if present,
+    # appends "key=value" at the end of the section otherwise. Creates
+    # the section (and the file) if they don't exist.
+    set -eu
+
+    CONF="${QBT_CONF:-/config/qBittorrent/qBittorrent.conf}"
+    TUPLES="${QBT_TUPLES:-/seed/entries.tsv}"
+
+    mkdir -p "$(dirname "$CONF")"
+    [ -f "$CONF" ] || : > "$CONF"
+
+    while IFS="	" read -r section key value; do
+      [ -z "${section:-}" ] && continue
+      case "$section" in \#*) continue ;; esac
+
+      # Pass values through ENVIRON so awk does not interpret backslash
+      # escapes (qBittorrent keys like "Session\DiskIOType" contain literal
+      # backslashes that -v would mangle).
+      QBT_SECTION="[$section]" QBT_KEY="$key" QBT_VALUE="$value" awk '
+        BEGIN {
+          section = ENVIRON["QBT_SECTION"]
+          key     = ENVIRON["QBT_KEY"]
+          value   = ENVIRON["QBT_VALUE"]
+          in_section = 0; replaced = 0; section_seen = 0
+        }
+        # Section header line
+        /^\[.*\]$/ {
+          # Leaving the target section without having replaced -> append before exiting it
+          if (in_section && !replaced) {
+            print key "=" value
+            replaced = 1
+          }
+          in_section = ($0 == section)
+          if (in_section) section_seen = 1
+          print
+          next
+        }
+        # Inside target section: replace existing key
+        in_section && index($0, key "=") == 1 {
+          if (!replaced) {
+            print key "=" value
+            replaced = 1
+          }
+          next
+        }
+        { print }
+        END {
+          if (!section_seen) {
+            print section
+            print key "=" value
+          } else if (in_section && !replaced) {
+            # File ended while still inside target section
+            print key "=" value
+          }
+        }
+      ' "$CONF" > "$CONF.tmp"
+      mv "$CONF.tmp" "$CONF"
+      echo "upserted [$section] $key=$value"
+    done < "$TUPLES"
+{{- end }}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -15,6 +15,34 @@ fullnameOverride: ""
 # -- Number of replicas to be deployed
 replicaCount: 1
 
+# qBittorrent.conf seeding / enforcement.
+# When enabled, an init container upserts the keys defined under `entries`
+# into /config/qBittorrent/qBittorrent.conf on every pod start. Existing
+# values for those specific keys are overwritten; all other keys (and any
+# changes made via the WebUI to keys not listed here) are preserved.
+#
+# Keys are organised by INI section. The default set targets the
+# libtorrent v2.x memory-mapped-IO problem:
+#   - DiskIOType=3 (Simple pread/pwrite) bypasses mmap-based caching.
+#   - MemoryWorkingSetLimit caps qBittorrent's working set in MiB.
+#   - UseOSCache=false stops leaning on the kernel page cache.
+qbittorrentConf:
+  # -- Enable the qBittorrent.conf init container
+  enabled: false
+  # -- INI sections and keys to upsert. Use Qt-style sub-keys with backslashes
+  # (e.g. `Session\DiskIOType`). Values are written verbatim — keep them as
+  # plain strings/integers/booleans.
+  entries:
+    BitTorrent:
+      Session\DiskIOType: 3
+      Session\MemoryWorkingSetLimit: 4096
+      Session\UseOSCache: false
+  # -- Image used by the seeding init container. Needs `awk` and `sh`.
+  image:
+    repository: busybox
+    tag: "1.36"
+    pullPolicy: IfNotPresent
+
 # Service configuration for qBittorrent
 service:
   # -- Service type


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism to pin a configurable set of `qBittorrent.conf` keys into `/config/qBittorrent/qBittorrent.conf` on every pod start, via an init container. Idempotent: replaces existing keys in place, appends missing ones, creates the section/file if absent. Only listed keys are touched — WebUI changes to other keys are preserved across restarts.

The default entries target the libtorrent v2.x memory-mapped-IO behaviour ([context](https://github.com/arvidn/libtorrent/issues/7551)), which causes runaway page-cache usage in containers — but the `entries` map is fully generic, so users can pin any qBittorrent.conf key (rate limits, ports, save paths, WebUI config, etc.).

This is **additive and opt-in** (`qbittorrentConf.enabled: false` by default). Existing deployments are unaffected.

## What's new

- `qbittorrentConf.enabled` (default `false`) — toggles the init container.
- `qbittorrentConf.entries` — `section -> { key: value }` map serialised to TSV in a ConfigMap and applied by a small `awk` upsert script in the init container. Default entries cover the three libtorrent-v2 mitigations: `Session\DiskIOType=3`, `Session\MemoryWorkingSetLimit=4096`, `Session\UseOSCache=false`.
- `qbittorrentConf.image` — image for the init container (default `busybox:1.36`).
- New template: `templates/qbittorrent-conf.yaml` (ConfigMap with `entries.tsv` + `upsert.sh`).
- Existing `initContainers:` block in `deployment.yaml` refactored so it can host either / both of the wireguard `copy-config` init container and the new `seed-qbittorrent-conf` init container.
- README section with discovery flow (configure via WebUI → cat the conf → copy keys into values) and worked examples (rate limits, fixed listen port, WebUI/save-path pinning).
- Chart bump: `2.0.1` → `2.1.0`.

## How the upsert works

For each `(section, key, value)` tuple, the init container runs an `awk` script against `/config/qBittorrent/qBittorrent.conf` that:
- creates the file (and section) if missing,
- replaces the existing `key=...` line inside the target section if present,
- appends `key=value` at the end of the section otherwise.

Values flow through `ENVIRON[]` (not `awk -v`) to preserve the literal backslashes in Qt-style keys like `Session\DiskIOType`.

## Test plan

- [x] `helm lint charts/qbittorrent` — clean
- [x] `helm template` with defaults — no ConfigMap, no init container (back-compat)
- [x] `helm template` with `qbittorrentConf.enabled=true` — renders ConfigMap + init container
- [x] `helm template` with both `qbittorrentConf.enabled=true` and `vpn.wireguard.enabled=true` — both init containers render in correct order (`copy-config` then `seed-qbittorrent-conf`)
- [x] Local upsert smoke test, three cases:
  - existing `[BitTorrent]` section with conflicting `DiskIOType=1` → replaced in place, other keys preserved
  - empty / missing config file → section + keys created
  - existing config without `[BitTorrent]` section → section appended at end
- [x] Idempotent: running the upsert twice produces an identical file (verified via `diff`)

## Follow-up

A separate PR will switch the chart's default image to `release-5.2.0` (libtorrent v2.x) and flip `qbittorrentConf.enabled` to `true` by default — that's a breaking change and will land as `3.0.0`.