### PR TITLE
qbittorrent: modern qBittorrent 5.x as default (chart 3.0.0)

### DIFF
--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying a QBittorrent client that uses a wiregua
 home: https://www.qbittorrent.org/
 icon: https://cloud.githubusercontent.com/assets/14862437/23586868/89ef2922-01c4-11e7-869c-52aafcece17f.png
 type: application
-version: 2.1.0
-appVersion: "legacy-4.3.9"  # legacy stable version
+version: 3.0.0
+appVersion: "release-5.2.0"  # modern qBittorrent on libtorrent v2.x
 kubeVersion: ">=1.19.0-0"
 keywords:
   - qbittorrent
@@ -27,4 +27,4 @@ annotations:
       url: https://github.com/hotio/qbittorrent
   artifacthub.io/images: |
     - name: qbittorrent
-      image: ghcr.io/hotio/qbittorrent:legacy-4.3.9
+      image: ghcr.io/hotio/qbittorrent:release-5.2.0

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -1,12 +1,78 @@
 # QBittorrent Chart
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: legacy-4.3.9](https://img.shields.io/badge/AppVersion-legacy--4.3.9-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.2.0](https://img.shields.io/badge/AppVersion-release--5.2.0-informational?style=flat-square)
 
 A Helm chart for deploying a QBittorrent client that uses a wireguard VPN tunnel.
 
 ## Important note
 
-**By default, this chart uses the 4.3.9 version of qBittorrent, known to be stable.**
+**Since chart 3.0.0, the default image is qBittorrent 5.x on libtorrent v2.x
+(`ghcr.io/hotio/qbittorrent:release-5.2.0`).** The legacy 4.3.9 image is still
+fully supported — see [Pinning the legacy image](#pinning-the-legacy-image)
+below.
+
+## Breaking Changes in v3.0.0
+
+**⚠️ Important:** Version 3.0.0 switches the default qBittorrent image from
+the legacy `legacy-4.3.9` build to the modern `release-5.2.0` build, and
+flips two related defaults to keep the new image stable in containers.
+
+### What changed
+
+| | v2.x default | v3.0.0 default |
+| --- | --- | --- |
+| `appVersion` (image tag) | `legacy-4.3.9` | `release-5.2.0` |
+| `env.LIBTORRENT` | (unset → image default `v1`) | `v2` |
+| `qbittorrentConf.enabled` | `false` | `true` |
+
+The libtorrent-v2.x build is the upstream default and gets all current
+fixes, but its memory-mapped IO interacts badly with the Linux page cache
+inside containers
+([context](https://github.com/arvidn/libtorrent/issues/7551)). The
+`qbittorrentConf` init container introduced in 2.1.0 is now enabled by
+default and pins three keys that defuse the issue:
+
+```
+[BitTorrent]
+Session\DiskIOType=3            # Simple pread/pwrite (bypasses mmap)
+Session\MemoryWorkingSetLimit=4096
+Session\UseOSCache=false
+```
+
+### Why this change?
+
+- 4.3.9 is from 2021 and no longer receives security or correctness fixes
+  upstream.
+- The mmap memory-growth problem that originally justified pinning legacy
+  is now mitigated *inside the chart*, not just by image choice.
+- New users hitting the chart for the first time should land on a current
+  qBittorrent.
+
+### Migration
+
+**If you've been pinning `image.tag` explicitly (e.g. `legacy-4.3.9` or a
+specific `release-*` tag):** nothing changes — your pin still wins.
+
+**If you were relying on the chart default and want to upgrade to 5.x:**
+just `helm upgrade` to 3.0.0. Note one-way migration of `.fastresume`
+files: once libtorrent-v2 has touched your resume data, rolling back to
+the legacy image requires re-checking torrents.
+
+**If you want to stay on legacy:** see below.
+
+### Pinning the legacy image
+
+```yaml
+image:
+  tag: legacy-4.3.9
+env:
+  LIBTORRENT: v1
+qbittorrentConf:
+  enabled: false   # legacy doesn't need the mmap mitigations
+```
+
+This restores the 2.x behaviour exactly. Resume data created on legacy is
+forward-compatible with libtorrent v2, so you can switch back later.
 
 ## Breaking Changes in v2.0.0
 
@@ -357,6 +423,7 @@ qbittorrentConf:
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity/anti-affinity settings |
 | commonLabels | object | {} | Common labels for all resources created by this chart |
+| env.LIBTORRENT | string | "v2" | Selects the libtorrent variant baked into the hotio image. `v2` matches the default appVersion (release-5.x); set to `v1` to pull the libtorrent 1.2.x build for the same qBittorrent version. |
 | env.PGID | int | `1000` | The group ID (GID) for running the container Ensures files are created with the correct group ownership |
 | env.PRIVOXY_ENABLED | bool | `false` | Enable Privoxy HTTP proxy |
 | env.PUID | int | `1000` | The user ID (UID) for running the container Ensures files are created with the correct user ownership |
@@ -394,7 +461,7 @@ qbittorrentConf:
 | persistence.data.accessMode | string | `"ReadWriteOnce"` | Access mode for the data PVC |
 | persistence.data.enabled | bool | `false` | Enable persistent storage for downloads |
 | persistence.data.size | string | `"500Gi"` | Size of the data PVC |
-| qbittorrentConf.enabled | bool | `false` | Enable the qBittorrent.conf init container |
+| qbittorrentConf.enabled | bool | `true` | Enable the qBittorrent.conf init container. Defaults to true since 3.0.0 because the chart's default image now ships libtorrent v2.x, which needs these mitigations to behave well in containers. |
 | qbittorrentConf.entries | object | `{"BitTorrent":{"Session\\DiskIOType":3,"Session\\MemoryWorkingSetLimit":4096,"Session\\UseOSCache":false}}` | INI sections and keys to upsert. Use Qt-style sub-keys with backslashes (e.g. `Session\DiskIOType`). Values are written verbatim — keep them as plain strings/integers/booleans. |
 | qbittorrentConf.image | object | `{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.36"}` | Image used by the seeding init container. Needs `awk` and `sh`. |
 | replicaCount | int | `1` | Number of replicas to be deployed |

--- a/charts/qbittorrent/README.md.gotmpl
+++ b/charts/qbittorrent/README.md.gotmpl
@@ -6,7 +6,73 @@
 
 ## Important note
 
-**By default, this chart uses the 4.3.9 version of qBittorrent, known to be stable.**
+**Since chart 3.0.0, the default image is qBittorrent 5.x on libtorrent v2.x
+(`ghcr.io/hotio/qbittorrent:release-5.2.0`).** The legacy 4.3.9 image is still
+fully supported — see [Pinning the legacy image](#pinning-the-legacy-image)
+below.
+
+## Breaking Changes in v3.0.0
+
+**⚠️ Important:** Version 3.0.0 switches the default qBittorrent image from
+the legacy `legacy-4.3.9` build to the modern `release-5.2.0` build, and
+flips two related defaults to keep the new image stable in containers.
+
+### What changed
+
+| | v2.x default | v3.0.0 default |
+| --- | --- | --- |
+| `appVersion` (image tag) | `legacy-4.3.9` | `release-5.2.0` |
+| `env.LIBTORRENT` | (unset → image default `v1`) | `v2` |
+| `qbittorrentConf.enabled` | `false` | `true` |
+
+The libtorrent-v2.x build is the upstream default and gets all current
+fixes, but its memory-mapped IO interacts badly with the Linux page cache
+inside containers
+([context](https://github.com/arvidn/libtorrent/issues/7551)). The
+`qbittorrentConf` init container introduced in 2.1.0 is now enabled by
+default and pins three keys that defuse the issue:
+
+```
+[BitTorrent]
+Session\DiskIOType=3            # Simple pread/pwrite (bypasses mmap)
+Session\MemoryWorkingSetLimit=4096
+Session\UseOSCache=false
+```
+
+### Why this change?
+
+- 4.3.9 is from 2021 and no longer receives security or correctness fixes
+  upstream.
+- The mmap memory-growth problem that originally justified pinning legacy
+  is now mitigated *inside the chart*, not just by image choice.
+- New users hitting the chart for the first time should land on a current
+  qBittorrent.
+
+### Migration
+
+**If you've been pinning `image.tag` explicitly (e.g. `legacy-4.3.9` or a
+specific `release-*` tag):** nothing changes — your pin still wins.
+
+**If you were relying on the chart default and want to upgrade to 5.x:**
+just `helm upgrade` to 3.0.0. Note one-way migration of `.fastresume`
+files: once libtorrent-v2 has touched your resume data, rolling back to
+the legacy image requires re-checking torrents.
+
+**If you want to stay on legacy:** see below.
+
+### Pinning the legacy image
+
+```yaml
+image:
+  tag: legacy-4.3.9
+env:
+  LIBTORRENT: v1
+qbittorrentConf:
+  enabled: false   # legacy doesn't need the mmap mitigations
+```
+
+This restores the 2.x behaviour exactly. Resume data created on legacy is
+forward-compatible with libtorrent v2, so you can switch back later.
 
 ## Breaking Changes in v2.0.0
 

--- a/charts/qbittorrent/templates/_helpers.tpl
+++ b/charts/qbittorrent/templates/_helpers.tpl
@@ -68,6 +68,10 @@ Create environment variables used to configure the qbittorrent container as well
   value: {{ .Values.env.UMASK | quote }}
 - name: TZ
   value: {{ .Values.env.TZ | quote }}
+{{- if .Values.env.LIBTORRENT }}
+- name: LIBTORRENT
+  value: {{ .Values.env.LIBTORRENT | quote }}
+{{- end }}
 {{- if or .Values.vpn.pia.enabled .Values.vpn.wireguard.enabled }}
 - name: VPN_ENABLED
   value: "true"

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -27,8 +27,11 @@ replicaCount: 1
 #   - MemoryWorkingSetLimit caps qBittorrent's working set in MiB.
 #   - UseOSCache=false stops leaning on the kernel page cache.
 qbittorrentConf:
-  # -- Enable the qBittorrent.conf init container
-  enabled: false
+  # -- Enable the qBittorrent.conf init container.
+  # Defaults to true since 3.0.0 because the chart's default image now
+  # ships libtorrent v2.x, which needs these mitigations to behave well
+  # in containers.
+  enabled: true
   # -- INI sections and keys to upsert. Use Qt-style sub-keys with backslashes
   # (e.g. `Session\DiskIOType`). Values are written verbatim — keep them as
   # plain strings/integers/booleans.
@@ -72,6 +75,12 @@ env:
   # -- Timezone setting
   # @default -- "Etc/UTC"
   TZ: "Etc/UTC"
+
+  # -- Selects the libtorrent variant baked into the hotio image.
+  # `v2` matches the default appVersion (release-5.x); set to `v1` to
+  # pull the libtorrent 1.2.x build for the same qBittorrent version.
+  # @default -- "v2"
+  LIBTORRENT: "v2"
 
   # -- VPN Configuration Settings
   # @section VPN Configuration


### PR DESCRIPTION
## Summary

Switches the chart's default image from the legacy `legacy-4.3.9` build to the modern `release-5.2.0` build (libtorrent v2.x), and flips two related defaults so the new image behaves well in containers out of the box.

Builds on #60 — the `qbittorrentConf` init container introduced there is now enabled by default and pins the three keys that defuse the libtorrent-v2 mmap + Linux page-cache growth pattern.

## What changed

| | v2.x default | v3.0.0 default |
| --- | --- | --- |
| `appVersion` (image tag) | `legacy-4.3.9` | `release-5.2.0` |
| `env.LIBTORRENT` | unset (image default `v1`) | `v2` |
| `qbittorrentConf.enabled` | `false` | `true` |

Also wires `LIBTORRENT` into the env helper (`templates/_helpers.tpl`) — it was previously declared in `values.yaml` but never reached the container.

## Why

- Legacy 4.3.9 is from 2021 and no longer receives security or correctness fixes upstream.
- The mmap memory-growth issue that originally justified pinning legacy is now mitigated *inside the chart*, not just by image choice.
- New users hitting the chart for the first time should land on a current qBittorrent.

## Migration

- **Pinning `image.tag` explicitly** (e.g. `legacy-4.3.9` or any `release-*`): nothing changes — your pin still wins.
- **Relying on the chart default**: `helm upgrade` to 3.0.0 moves you to qBittorrent 5.x on libtorrent v2.x with the mitigations active. Note: once libtorrent v2 has touched `.fastresume` files, rolling back to legacy requires re-checking torrents.
- **Want to stay on legacy**: full opt-out documented in the README:

  ```yaml
  image:
    tag: legacy-4.3.9
  env:
    LIBTORRENT: v1
  qbittorrentConf:
    enabled: false
  ```

## Test plan

- [x] `helm lint charts/qbittorrent` — clean
- [x] `helm template` with defaults — renders `release-5.2.0` image, `LIBTORRENT=v2` env, `qbittorrent-conf` ConfigMap, and `seed-qbittorrent-conf` init container
- [x] `helm template` with full legacy opt-out (`image.tag=legacy-4.3.9`, `env.LIBTORRENT=v1`, `qbittorrentConf.enabled=false`) — no ConfigMap, no init container, `LIBTORRENT=v1` reaches the container, image is `legacy-4.3.9` (i.e. exact 2.x behaviour restored)
- [x] Rebased cleanly onto merged 2.1.0 (`#60`)

## Files

- `Chart.yaml` — `version: 2.1.0 → 3.0.0`, `appVersion: legacy-4.3.9 → release-5.2.0`, artifacthub image annotation updated
- `values.yaml` — `qbittorrentConf.enabled: false → true`, new `env.LIBTORRENT: "v2"`
- `templates/_helpers.tpl` — render `LIBTORRENT` env var when set
- `README.md` / `README.md.gotmpl` — "Important note" rewritten, new "Breaking Changes in v3.0.0" section with migration + legacy opt-out, "Pinning the legacy image" snippet