### PR TITLE
valheim-server: support static NodePort assignments (chart 1.1.0)

### DIFF
--- a/charts/valheim-server/Chart.yaml
+++ b/charts/valheim-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valheim-server
 description: A Helm chart for deploying a Valheim dedicated server on Kubernetes
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "3.1.0"
 home: https://www.valheimgame.com/
 icon: https://cdn2.steamgriddb.com/icon/d17892563a6984845a0e23df7841f903/32/256x256.png

--- a/charts/valheim-server/README.md
+++ b/charts/valheim-server/README.md
@@ -1,6 +1,6 @@
 # valheim-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 A Helm chart for deploying a Valheim dedicated server on Kubernetes
 
@@ -181,6 +181,9 @@ kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 | service.annotations | object | `{}` | Annotations for the service |
 | service.loadBalancerIP | string | `""` | Set specific load balancer IP (depends on cloud provider support) |
 | service.loadBalancerSourceRanges | list | `[]` | External source IP ranges allowed to access the server |
+| service.nodePorts.game | string | `""` | NodePort for the game port (server.port) |
+| service.nodePorts.game1 | string | `""` | NodePort for server.port + 1 |
+| service.nodePorts.game2 | string | `""` | NodePort for server.port + 2 |
 | service.type | string | `"LoadBalancer"` | Service type |
 | startupProbe.enabled | bool | `true` | Enable startup probe |
 | startupProbe.failureThreshold | int | 30 (allows up to 5 minutes for initial startup) | Failure threshold |

--- a/charts/valheim-server/templates/service.yaml
+++ b/charts/valheim-server/templates/service.yaml
@@ -22,13 +22,22 @@ spec:
       targetPort: game
       protocol: UDP
       name: game
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePorts.game }}
+      nodePort: {{ .Values.service.nodePorts.game }}
+      {{- end }}
     - port: {{ add .Values.server.port 1 }}
       targetPort: game-1
       protocol: UDP
       name: game-1
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePorts.game1 }}
+      nodePort: {{ .Values.service.nodePorts.game1 }}
+      {{- end }}
     - port: {{ add .Values.server.port 2 }}
       targetPort: game-2
       protocol: UDP
       name: game-2
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePorts.game2 }}
+      nodePort: {{ .Values.service.nodePorts.game2 }}
+      {{- end }}
   selector:
     {{- include "valheim-server.selectorLabels" . | nindent 4 }}

--- a/charts/valheim-server/values.yaml
+++ b/charts/valheim-server/values.yaml
@@ -70,6 +70,15 @@ service:
   annotations: {}
   # -- External source IP ranges allowed to access the server
   loadBalancerSourceRanges: []
+  # Static NodePort assignments (only used when service.type is "NodePort").
+  # Leave a field empty to let Kubernetes auto-assign a port in the NodePort range.
+  nodePorts:
+    # -- NodePort for the game port (server.port)
+    game: ""
+    # -- NodePort for server.port + 1
+    game1: ""
+    # -- NodePort for server.port + 2
+    game2: ""
 
 # Storage configuration for server data
 persistence:


### PR DESCRIPTION
## Summary
- Add `service.nodePorts.{game,game1,game2}` so users can pin the three UDP NodePorts when `service.type: NodePort` (previously they were always auto-assigned in 30000–32767, making the server effectively unreachable on its expected 2456–2458 ports).
- Bump chart version 1.0.0 → 1.1.0 and regenerate README.

## Test plan
- [x] `helm lint charts/valheim-server`
- [x] `helm template charts/valheim-server --set service.type=NodePort --set service.nodePorts.game=30456 ...` renders `nodePort:` on each port
- [x] `pre-commit run helm-docs` (README regenerated)
- [ ] CI `ct lint` passes