### PR TITLE
Add alertmanager-ntfy chart (AGPL fork)

### DIFF
--- a/charts/alertmanager-ntfy/Chart.yaml
+++ b/charts/alertmanager-ntfy/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: alertmanager-ntfy
+description: Bridge that receives Alertmanager webhooks and forwards them to a ntfy server.
+type: application
+version: 0.2.0
+# renovate: image=codeberg.org/xenrox/ntfy-alertmanager
+appVersion: "1.0.0"
+kubeVersion: ">=1.19.0-0"
+home: https://codeberg.org/xenrox/ntfy-alertmanager
+icon: https://github.com/binwiederhier/ntfy/raw/main/web/public/static/images/pwa-512x512.png
+maintainers:
+  - name: kriegalex
+    email: kriegalex@gmail.com
+keywords:
+  - alertmanager
+  - ntfy
+  - notifications
+  - monitoring
+sources:
+  - https://codeberg.org/xenrox/ntfy-alertmanager
+  - https://github.com/kriegalex/k8s-charts/tree/main/charts/alertmanager-ntfy
+deprecated: false
+annotations:
+  artifacthub.io/license: AGPL-3.0-only
+  artifacthub.io/links: |
+    - name: Upstream chart (xenrox/ntfy-alertmanager contrib/charts)
+      url: https://codeberg.org/xenrox/ntfy-alertmanager/src/branch/master/contrib/charts/alertmanager-ntfy
+    - name: Docker image source
+      url: https://codeberg.org/xenrox/ntfy-alertmanager
+    - name: Chart source
+      url: https://github.com/kriegalex/k8s-charts/tree/main/charts/alertmanager-ntfy
+  artifacthub.io/images: |
+    - name: ntfy-alertmanager
+      image: codeberg.org/xenrox/ntfy-alertmanager:1.0.0

--- a/charts/alertmanager-ntfy/LICENSE
+++ b/charts/alertmanager-ntfy/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/charts/alertmanager-ntfy/NOTICE
+++ b/charts/alertmanager-ntfy/NOTICE
@@ -22,12 +22,26 @@ Changes from upstream
   ntfy.markdown / template-path / generator-url-label, resolved.*,
   per-label icon/email-address/call/topic, alertmanager{} silence
   block, cache{} block) instead of the small whitelist the upstream
-  chart rendered.
-- templates/configmap.yaml: new optional ConfigMap that holds a
-  user-supplied Go text/template for the notification body, mounted
-  alongside the config Secret so ntfy.template-path can reference it.
-- templates/deployment.yaml: optional second volume/mount for the
-  template ConfigMap (gated on .Values.ntfyAlertmanager.template.enabled).
+  chart rendered. The Secret also carries an optional second key
+  `template.tmpl` holding a user-supplied Go text/template for the
+  notification body, gated on .Values.ntfyAlertmanager.template.enabled
+  and a non-empty body. Mounted via the existing Secret-as-directory
+  mount; no separate ConfigMap or extra volume is introduced.
+- templates/secret.yaml: tightened guards that the upstream chart
+  inherited from its scfg template — `markdown` uses kindIs "bool"
+  so `false` is honored (upstream's `with` swallowed it); empty
+  `topic` no longer emits a broken `topic` line; `password` without
+  a matching `user` is suppressed in the webhook-auth, ntfy, and
+  alertmanager{} blocks.
+- templates/_helpers.tpl: new alertmanager-ntfy.templatePath helper
+  resolves the bridge's template-path field from either an explicit
+  override or the auto-mount location when the template feature is
+  enabled with a non-empty body.
+- templates/deployment.yaml: probes use /health (matches binary
+  appVersion 1.0.0). Sets automountServiceAccountToken: false on
+  the PodSpec.
+- templates/serviceaccount.yaml: adds automountServiceAccountToken:
+  false on the SA, matching the repo-wide convention.
 - values.yaml: documented the new keys with helm-docs annotations;
   appVersion bumped to 1.0.0 so image.tag defaults track the current
   binary release.

--- a/charts/alertmanager-ntfy/NOTICE
+++ b/charts/alertmanager-ntfy/NOTICE
@@ -1,0 +1,33 @@
+alertmanager-ntfy Helm chart
+============================
+
+This chart is a fork of the upstream chart that ships in
+the xenrox/ntfy-alertmanager repository at:
+
+    https://codeberg.org/xenrox/ntfy-alertmanager
+    (contrib/charts/alertmanager-ntfy/)
+
+Upstream maintainer: WrenIX <https://wrenix.eu>
+Upstream license:    GNU Affero General Public License v3.0 (AGPL-3.0)
+
+This fork inherits AGPL-3.0 (see LICENSE in this directory).
+The rest of the kriegalex/k8s-charts repository remains under MIT;
+only this chart subtree is AGPL-3.0.
+
+Changes from upstream
+---------------------
+
+- templates/secret.yaml: expanded the rendered scfg config to expose
+  the full set of ntfy-alertmanager options (alert-mode, base-url,
+  ntfy.markdown / template-path / generator-url-label, resolved.*,
+  per-label icon/email-address/call/topic, alertmanager{} silence
+  block, cache{} block) instead of the small whitelist the upstream
+  chart rendered.
+- templates/configmap.yaml: new optional ConfigMap that holds a
+  user-supplied Go text/template for the notification body, mounted
+  alongside the config Secret so ntfy.template-path can reference it.
+- templates/deployment.yaml: optional second volume/mount for the
+  template ConfigMap (gated on .Values.ntfyAlertmanager.template.enabled).
+- values.yaml: documented the new keys with helm-docs annotations;
+  appVersion bumped to 1.0.0 so image.tag defaults track the current
+  binary release.

--- a/charts/alertmanager-ntfy/README.md
+++ b/charts/alertmanager-ntfy/README.md
@@ -1,0 +1,160 @@
+# alertmanager-ntfy
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+Bridge that receives Alertmanager webhooks and forwards them to a ntfy server.
+
+## Introduction
+
+This chart deploys [xenrox/ntfy-alertmanager](https://codeberg.org/xenrox/ntfy-alertmanager), a small bridge that receives Alertmanager webhooks and forwards them to a [ntfy](https://ntfy.sh) server with per-severity priority/tags/icons.
+
+It is a fork of the chart that ships in `xenrox/ntfy-alertmanager`'s `contrib/charts/` directory, extended to expose the full set of [scfg config options](https://codeberg.org/xenrox/ntfy-alertmanager/src/branch/master/config.scfg) the upstream binary supports — including `alert-mode`, `ntfy.template-path`, `ntfy.generator-url-label`, `resolved.update-notification`, the `alertmanager{}` silence-button block, and the `cache{}` block. The upstream chart only renders a small whitelist; this fork renders everything so you can tune notification verbosity without post-render patches.
+
+## License
+
+The upstream binary and chart are licensed under **AGPL-3.0**. This fork inherits that license — see [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE) in this directory. The remainder of the [`kriegalex/k8s-charts`](https://github.com/kriegalex/k8s-charts) repository is MIT; only this chart subtree is AGPL-3.0.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.16+
+- A reachable ntfy server (in-cluster or external) with a publisher credential
+
+## Installing the Chart
+
+```bash
+helm repo add k8s-charts https://kriegalex.github.io/k8s-charts/
+helm repo update
+helm install alertmanager-ntfy k8s-charts/alertmanager-ntfy \
+  --namespace ntfy --create-namespace \
+  -f values.yaml -f helm-values-secret.yaml
+```
+
+Credentials (the ntfy publisher password, optional webhook basic-auth) belong in a separate gitignored `helm-values-secret.yaml` so they don't land in version control.
+
+## Reducing notification verbosity
+
+The upstream binary's default formatter dumps every label and annotation into the notification body. Three knobs cut that down considerably on a phone:
+
+```yaml
+ntfyAlertmanager:
+  alertMode: single                # one ntfy message per alert; cleaner title
+  ntfy:
+    generatorUrlLabel: "View"      # adds an action button to the Prometheus alert URL
+  resolved:
+    updateNotification: true       # updates the original notification on resolve
+
+  # Optional: replace the default label/annotation dump with your own template.
+  template:
+    enabled: true
+    body: |
+      **{{ index .CommonAnnotations "summary" }}**
+
+      {{ index .CommonAnnotations "description" }}
+
+  # When alertMode is "single", enable a cache so re-evaluations of the same
+  # alert don't re-publish on every Alertmanager group_interval.
+  cache:
+    type: memory
+    duration: 24h
+```
+
+When `template.enabled` is true, the chart writes the template body into the config Secret as a second key (`template.tmpl`), mounts it at `/etc/ntfy-alertmanager/template.tmpl`, and sets `ntfy.template-path` automatically.
+
+> **Pair `alertMode: single` with a cache.** In single mode the bridge does not deduplicate per-alert by default — every Alertmanager re-evaluation (typically every 30 s while the alert is firing) re-publishes. Set `ntfyAlertmanager.cache.type: memory` and a duration matching your `repeat_interval` to suppress recurrences.
+
+## Silence button (optional)
+
+To enable the in-notification "Silence" button:
+
+```yaml
+ntfyAlertmanager:
+  baseURL: https://alertmanager-ntfy.example.com
+  alertmanager:
+    silenceDuration: 24h
+
+ingress:
+  enabled: true
+  hosts:
+    - host: alertmanager-ntfy.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+The Silence button on each ntfy message posts back to this Ingress, which the bridge proxies on to the Alertmanager API.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling. |
+| autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler. |
+| autoscaling.maxReplicas | int | `5` | Maximum replicas under autoscaling. |
+| autoscaling.minReplicas | int | `1` | Minimum replicas under autoscaling. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage. |
+| autoscaling.targetMemoryUtilizationPercentage | string | `""` | Target memory utilization percentage. |
+| fullnameOverride | string | `""` | Override the fully qualified app name. |
+| global.image.pullPolicy | string | `""` | Overwrites all imagePullPolicy entries if set. |
+| global.image.registry | string | `""` | Overwrites all registry entries if set. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy (overridable via global.image.pullPolicy). |
+| image.registry | string | `"codeberg.org"` | Image registry (overridable via global.image.registry). |
+| image.repository | string | `"xenrox/ntfy-alertmanager"` | Image repository. |
+| image.tag | string | `""` | Image tag. When empty, defaults to .Chart.AppVersion. |
+| imagePullSecrets | list | `[]` | Image pull secrets. |
+| ingress.annotations | object | `{}` | Ingress annotations. |
+| ingress.className | string | `""` | IngressClass name. |
+| ingress.enabled | bool | `false` | Expose the bridge through an Ingress (needed for the Silence button). |
+| ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | Ingress hosts/paths. |
+| ingress.tls | list | `[]` | Ingress TLS configuration. |
+| nameOverride | string | `""` | Override the chart name used in resource names. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling. |
+| ntfyAlertmanager.alertMode | string | `""` | How alerts are grouped into ntfy messages. "multi" keeps grouped alerts in one notification; "single" sends each alert separately (cleaner title, enables generator-url-label button). |
+| ntfyAlertmanager.alertmanager.password | string | `""` | Alertmanager basic-auth password. |
+| ntfyAlertmanager.alertmanager.silenceDuration | string | `""` | How long a silence created from the notification lasts (e.g. "24h"). |
+| ntfyAlertmanager.alertmanager.url | string | `""` | Override the Alertmanager URL parsed from the webhook payload. |
+| ntfyAlertmanager.alertmanager.user | string | `""` | Alertmanager basic-auth user when the API is protected. |
+| ntfyAlertmanager.baseURL | string | `""` | Public-facing base URL of the bridge. Required if you want the "Silence" action button (alertmanager.silenceDuration) to work. |
+| ntfyAlertmanager.cache.cleanupInterval | string | `""` | Memory cache cleanup interval. |
+| ntfyAlertmanager.cache.duration | string | `""` | How long entries stay in the cache. |
+| ntfyAlertmanager.cache.redisURL | string | `""` | Redis URL (only used when type is redis). |
+| ntfyAlertmanager.cache.type | string | `""` | Cache backend (disabled, memory, redis). |
+| ntfyAlertmanager.labels.entries | list | `[{"label":"severity","priority":5,"tags":["rotating_light"],"value":"critical"},{"label":"severity","priority":1,"value":"info"}]` | Per-label mapping entries. Each entry takes `label`, `value`, and any of: `priority`, `tags` (list), `icon`, `emailAddress`, `call`, `topic`. |
+| ntfyAlertmanager.labels.order | list | `["severity","instance"]` | Decreasing-priority list of label names to consult. |
+| ntfyAlertmanager.logFormat | string | `""` | Log format (text or json). |
+| ntfyAlertmanager.logLevel | string | `"info"` | Log level (debug, info, warning, error). |
+| ntfyAlertmanager.ntfy.accessToken | string | `""` | ntfy access token (alternative to user/password). |
+| ntfyAlertmanager.ntfy.call | string | `""` | Place a phone call for every alert (use "yes" for first verified). |
+| ntfyAlertmanager.ntfy.certificateFingerprint | string | `""` | SHA-512 certificate fingerprint for self-signed ntfy servers. |
+| ntfyAlertmanager.ntfy.emailAddress | string | `""` | Forward every alert to this email address via ntfy. |
+| ntfyAlertmanager.ntfy.generatorUrlLabel | string | `""` | Label for the action button that opens the alert's generator/Prometheus URL. Only effective when alertMode is "single". Example: "View". |
+| ntfyAlertmanager.ntfy.markdown | string | `""` | Render the notification body as Markdown. Empty = upstream default (true). |
+| ntfyAlertmanager.ntfy.password | string | `""` | ntfy publisher password. |
+| ntfyAlertmanager.ntfy.server | string | `""` | ntfy server URL when `topic` is just a topic name. |
+| ntfyAlertmanager.ntfy.templatePath | string | `""` | Absolute path inside the pod to a Go text/template file that overrides the default notification body. When `template.enabled` is true and this is left empty, it auto-fills to /etc/ntfy-alertmanager/template.tmpl. |
+| ntfyAlertmanager.ntfy.topic | string | `"https://ntfy.sh/alertmanager-alerts"` | URL of the ntfy topic (required). Either a full URL (https://ntfy.example.com/my-topic) or just the topic name when combined with `server`. |
+| ntfyAlertmanager.ntfy.user | string | `""` | ntfy publisher username. |
+| ntfyAlertmanager.password | string | `""` | HTTP basic auth password for the webhook endpoint. |
+| ntfyAlertmanager.port | int | `80` | Listening port for the webhook receiver. |
+| ntfyAlertmanager.resolved.icon | string | `""` | Icon URL for resolved-alert notifications. |
+| ntfyAlertmanager.resolved.priority | string | `""` | ntfy priority for resolved-alert notifications. |
+| ntfyAlertmanager.resolved.tags | list | `["white_check_mark"]` | Tags appended to resolved-alert notifications. |
+| ntfyAlertmanager.resolved.updateNotification | bool | `false` | Update the original ntfy notification instead of pushing a new one when an alert resolves. Halves the notification count in practice. |
+| ntfyAlertmanager.template.body | string | `""` | Go text/template source. See xenrox/ntfy-alertmanager docs for the available `.Alerts[]`, `.CommonLabels`, `.CommonAnnotations`, etc. |
+| ntfyAlertmanager.template.enabled | bool | `false` | Render the template ConfigMap and mount it into the pod. |
+| ntfyAlertmanager.user | string | `""` | Optional HTTP basic auth on the webhook endpoint itself (Alertmanager -> bridge). Leave empty for in-cluster trust. |
+| podAnnotations | object | `{}` | Extra annotations added to every Pod. |
+| podLabels | object | `{}` | Extra labels added to every Pod. |
+| podSecurityContext | object | `{}` | Pod-level securityContext. |
+| replicaCount | int | `1` | Number of replicas. |
+| resources | object | `{}` | Container resources. |
+| securityContext | object | `{}` | Container-level securityContext. |
+| service.port | int | `80` | Service port. |
+| service.type | string | `"ClusterIP"` | Service type. |
+| serviceAccount.annotations | object | `{}` | Service account annotations. |
+| serviceAccount.create | bool | `true` | Create a service account for the bridge. |
+| serviceAccount.name | string | `""` | Pre-existing service account name. Generated if empty and create is true. |
+| tolerations | list | `[]` | Tolerations for pod scheduling. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/alertmanager-ntfy/README.md.gotmpl
+++ b/charts/alertmanager-ntfy/README.md.gotmpl
@@ -1,0 +1,91 @@
+# {{ .Name }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+## Introduction
+
+This chart deploys [xenrox/ntfy-alertmanager](https://codeberg.org/xenrox/ntfy-alertmanager), a small bridge that receives Alertmanager webhooks and forwards them to a [ntfy](https://ntfy.sh) server with per-severity priority/tags/icons.
+
+It is a fork of the chart that ships in `xenrox/ntfy-alertmanager`'s `contrib/charts/` directory, extended to expose the full set of [scfg config options](https://codeberg.org/xenrox/ntfy-alertmanager/src/branch/master/config.scfg) the upstream binary supports — including `alert-mode`, `ntfy.template-path`, `ntfy.generator-url-label`, `resolved.update-notification`, the `alertmanager{}` silence-button block, and the `cache{}` block. The upstream chart only renders a small whitelist; this fork renders everything so you can tune notification verbosity without post-render patches.
+
+## License
+
+The upstream binary and chart are licensed under **AGPL-3.0**. This fork inherits that license — see [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE) in this directory. The remainder of the [`kriegalex/k8s-charts`](https://github.com/kriegalex/k8s-charts) repository is MIT; only this chart subtree is AGPL-3.0.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.16+
+- A reachable ntfy server (in-cluster or external) with a publisher credential
+
+## Installing the Chart
+
+```bash
+helm repo add k8s-charts https://kriegalex.github.io/k8s-charts/
+helm repo update
+helm install alertmanager-ntfy k8s-charts/alertmanager-ntfy \
+  --namespace ntfy --create-namespace \
+  -f values.yaml -f helm-values-secret.yaml
+```
+
+Credentials (the ntfy publisher password, optional webhook basic-auth) belong in a separate gitignored `helm-values-secret.yaml` so they don't land in version control.
+
+## Reducing notification verbosity
+
+The upstream binary's default formatter dumps every label and annotation into the notification body. Three knobs cut that down considerably on a phone:
+
+```yaml
+ntfyAlertmanager:
+  alertMode: single                # one ntfy message per alert; cleaner title
+  ntfy:
+    generatorUrlLabel: "View"      # adds an action button to the Prometheus alert URL
+  resolved:
+    updateNotification: true       # updates the original notification on resolve
+
+  # Optional: replace the default label/annotation dump with your own template.
+  template:
+    enabled: true
+    body: |
+      **{{ "{{" }} index .CommonAnnotations "summary" {{ "}}" }}**
+
+      {{ "{{" }} index .CommonAnnotations "description" {{ "}}" }}
+
+  # When alertMode is "single", enable a cache so re-evaluations of the same
+  # alert don't re-publish on every Alertmanager group_interval.
+  cache:
+    type: memory
+    duration: 24h
+```
+
+When `template.enabled` is true, the chart writes the template body into the config Secret as a second key (`template.tmpl`), mounts it at `/etc/ntfy-alertmanager/template.tmpl`, and sets `ntfy.template-path` automatically.
+
+> **Pair `alertMode: single` with a cache.** In single mode the bridge does not deduplicate per-alert by default — every Alertmanager re-evaluation (typically every 30 s while the alert is firing) re-publishes. Set `ntfyAlertmanager.cache.type: memory` and a duration matching your `repeat_interval` to suppress recurrences.
+
+## Silence button (optional)
+
+To enable the in-notification "Silence" button:
+
+```yaml
+ntfyAlertmanager:
+  baseURL: https://alertmanager-ntfy.example.com
+  alertmanager:
+    silenceDuration: 24h
+
+ingress:
+  enabled: true
+  hosts:
+    - host: alertmanager-ntfy.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+The Silence button on each ntfy message posts back to this Ingress, which the bridge proxies on to the Alertmanager API.
+
+## Configuration
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/alertmanager-ntfy/templates/NOTES.txt
+++ b/charts/alertmanager-ntfy/templates/NOTES.txt
@@ -1,0 +1,23 @@
+alertmanager-ntfy has been installed.
+
+Point Alertmanager at this webhook receiver:
+
+  receivers:
+    - name: ntfy
+      webhook_configs:
+        - url: http://{{ include "alertmanager-ntfy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/
+          send_resolved: true
+
+Effective ntfy topic: {{ .Values.ntfyAlertmanager.ntfy.topic }}
+
+{{- if .Values.ntfyAlertmanager.template.enabled }}
+
+A custom notification body template is mounted at
+/etc/ntfy-alertmanager/template.tmpl and referenced via ntfy.template-path.
+{{- end }}
+
+Verify the rendered scfg config:
+
+  kubectl --namespace {{ .Release.Namespace }} get secret \
+    {{ include "alertmanager-ntfy.fullname" . }} \
+    -o jsonpath='{.data.config}' | base64 -d

--- a/charts/alertmanager-ntfy/templates/_helpers.tpl
+++ b/charts/alertmanager-ntfy/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertmanager-ntfy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "alertmanager-ntfy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alertmanager-ntfy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alertmanager-ntfy.labels" -}}
+helm.sh/chart: {{ include "alertmanager-ntfy.chart" . }}
+{{ include "alertmanager-ntfy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alertmanager-ntfy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertmanager-ntfy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "alertmanager-ntfy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alertmanager-ntfy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the ntfy template-path. If the user opted into the rendered
+template ConfigMap and didn't set their own path, default to the mount
+point. Returns empty when the binary should use its built-in formatter.
+*/}}
+{{- define "alertmanager-ntfy.templatePath" -}}
+{{- if .Values.ntfyAlertmanager.ntfy.templatePath -}}
+{{- .Values.ntfyAlertmanager.ntfy.templatePath -}}
+{{- else if and .Values.ntfyAlertmanager.template.enabled .Values.ntfyAlertmanager.template.body -}}
+/etc/ntfy-alertmanager/template.tmpl
+{{- end -}}
+{{- end -}}

--- a/charts/alertmanager-ntfy/templates/deployment.yaml
+++ b/charts/alertmanager-ntfy/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alertmanager-ntfy.fullname" . }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "alertmanager-ntfy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        confighash: {{ .Values.ntfyAlertmanager | toYaml | sha256sum | trunc 32 }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "alertmanager-ntfy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "alertmanager-ntfy.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.image }}
+          image: "{{ coalesce $.Values.global.image.registry .registry }}/{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ coalesce $.Values.global.image.pullPolicy .pullPolicy }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ntfyAlertmanager.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/ntfy-alertmanager
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "alertmanager-ntfy.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/alertmanager-ntfy/templates/hpa.yaml
+++ b/charts/alertmanager-ntfy/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "alertmanager-ntfy.fullname" . }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "alertmanager-ntfy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/alertmanager-ntfy/templates/ingress.yaml
+++ b/charts/alertmanager-ntfy/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "alertmanager-ntfy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/alertmanager-ntfy/templates/secret.yaml
+++ b/charts/alertmanager-ntfy/templates/secret.yaml
@@ -1,0 +1,144 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alertmanager-ntfy.fullname" . }}
+  annotations:
+    confighash: {{ .Values.ntfyAlertmanager | toYaml | sha256sum | trunc 32 }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.ntfyAlertmanager }}
+  config: |
+    http-address :{{ .port }}
+    log-level {{ .logLevel }}
+    {{- with .logFormat }}
+    log-format {{ . }}
+    {{- end }}
+    {{- with .baseURL }}
+    base-url {{ . }}
+    {{- end }}
+    {{- with .alertMode }}
+    alert-mode {{ . }}
+    {{- end }}
+    {{- if and .user .password }}
+    user {{ .user }}
+    password {{ .password }}
+    {{- end }}
+    {{- with .ntfy }}
+    ntfy {
+      {{- with .topic }}
+      topic {{ . }}
+      {{- end }}
+      {{- with .server }}
+      server {{ . }}
+      {{- end }}
+      {{- if and .user .password }}
+      user {{ .user }}
+      password {{ .password }}
+      {{- end }}
+      {{- with .accessToken }}
+      access-token {{ . }}
+      {{- end }}
+      {{- with .certificateFingerprint }}
+      certificate-fingerprint {{ . }}
+      {{- end }}
+      {{- with .emailAddress }}
+      email-address {{ . }}
+      {{- end }}
+      {{- with .call }}
+      call {{ . }}
+      {{- end }}
+      {{- if kindIs "bool" .markdown }}
+      markdown {{ .markdown }}
+      {{- end }}
+      {{- with .generatorUrlLabel }}
+      generator-url-label {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- $tpath := include "alertmanager-ntfy.templatePath" $ }}
+    {{- with $tpath }}
+      template-path {{ . | quote }}
+    {{- end }}
+    {{- if .ntfy }}
+    }
+    {{- end }}
+    {{- with .labels }}
+    labels {
+      order {{ .order | join "," | quote }}
+      {{- range .entries }}
+      {{ .label }} {{ .value | quote }} {
+        {{- with .priority }}
+        priority {{ . }}
+        {{- end }}
+        {{- with .tags }}
+        tags {{ . | join "," | quote }}
+        {{- end }}
+        {{- with .icon }}
+        icon {{ . | quote }}
+        {{- end }}
+        {{- with .emailAddress }}
+        email-address {{ . }}
+        {{- end }}
+        {{- with .call }}
+        call {{ . }}
+        {{- end }}
+        {{- with .topic }}
+        topic {{ . }}
+        {{- end }}
+      }
+      {{- end }}
+    }
+    {{- end }}
+    {{- with .resolved }}
+    resolved {
+        {{- with .updateNotification }}
+        update-notification {{ . }}
+        {{- end }}
+        {{- with .tags }}
+        tags {{ . | join "," | quote }}
+        {{- end }}
+        {{- with .priority }}
+        priority {{ . }}
+        {{- end }}
+        {{- with .icon }}
+        icon {{ . | quote }}
+        {{- end }}
+    }
+    {{- end }}
+    {{- with .alertmanager }}
+    {{- if or .silenceDuration .user .url }}
+    alertmanager {
+      {{- with .silenceDuration }}
+      silence-duration {{ . }}
+      {{- end }}
+      {{- if and .user .password }}
+      user {{ .user }}
+      password {{ .password }}
+      {{- end }}
+      {{- with .url }}
+      url {{ . }}
+      {{- end }}
+    }
+    {{- end }}
+    {{- end }}
+    {{- with .cache }}
+    {{- if .type }}
+    cache {
+      type {{ .type }}
+      {{- with .duration }}
+      duration {{ . }}
+      {{- end }}
+      {{- with .cleanupInterval }}
+      cleanup-interval {{ . }}
+      {{- end }}
+      {{- with .redisURL }}
+      redis-url {{ . }}
+      {{- end }}
+    }
+    {{- end }}
+    {{- end }}
+  {{- if and .template.enabled .template.body }}
+  template.tmpl: |
+{{ .template.body | indent 4 }}
+  {{- end }}
+  {{- end }}

--- a/charts/alertmanager-ntfy/templates/service.yaml
+++ b/charts/alertmanager-ntfy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertmanager-ntfy.fullname" . }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "alertmanager-ntfy.selectorLabels" . | nindent 4 }}

--- a/charts/alertmanager-ntfy/templates/serviceaccount.yaml
+++ b/charts/alertmanager-ntfy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alertmanager-ntfy.serviceAccountName" . }}
+  labels:
+    {{- include "alertmanager-ntfy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/alertmanager-ntfy/values.yaml
+++ b/charts/alertmanager-ntfy/values.yaml
@@ -1,0 +1,208 @@
+global:
+  image:
+    # -- Overwrites all registry entries if set.
+    registry: ""
+    # -- Overwrites all imagePullPolicy entries if set.
+    pullPolicy: ""
+
+# -- Number of replicas.
+replicaCount: 1
+
+image:
+  # -- Image registry (overridable via global.image.registry).
+  registry: codeberg.org
+  # -- Image repository.
+  repository: xenrox/ntfy-alertmanager
+  # -- Image pull policy (overridable via global.image.pullPolicy).
+  pullPolicy: IfNotPresent
+  # -- Image tag. When empty, defaults to .Chart.AppVersion.
+  tag: ""
+
+# ntfy-alertmanager rendered config (scfg). Every field is optional unless
+# noted; empty/unset fields are omitted from the rendered config so the
+# binary falls back to its own defaults.
+ntfyAlertmanager:
+  # -- Listening port for the webhook receiver.
+  port: 80
+  # -- Log level (debug, info, warning, error).
+  logLevel: info
+  # -- Log format (text or json).
+  logFormat: ""
+  # -- Public-facing base URL of the bridge. Required if you want the
+  # "Silence" action button (alertmanager.silenceDuration) to work.
+  baseURL: ""
+  # -- How alerts are grouped into ntfy messages. "multi" keeps grouped
+  # alerts in one notification; "single" sends each alert separately
+  # (cleaner title, enables generator-url-label button).
+  alertMode: ""
+  # -- Optional HTTP basic auth on the webhook endpoint itself
+  # (Alertmanager -> bridge). Leave empty for in-cluster trust.
+  user: ""
+  # -- HTTP basic auth password for the webhook endpoint.
+  password: ""
+
+  ntfy:
+    # -- URL of the ntfy topic (required). Either a full URL
+    # (https://ntfy.example.com/my-topic) or just the topic name when
+    # combined with `server`.
+    topic: https://ntfy.sh/alertmanager-alerts
+    # -- ntfy server URL when `topic` is just a topic name.
+    server: ""
+    # -- ntfy publisher username.
+    user: ""
+    # -- ntfy publisher password.
+    password: ""
+    # -- ntfy access token (alternative to user/password).
+    accessToken: ""
+    # -- SHA-512 certificate fingerprint for self-signed ntfy servers.
+    certificateFingerprint: ""
+    # -- Forward every alert to this email address via ntfy.
+    emailAddress: ""
+    # -- Place a phone call for every alert (use "yes" for first verified).
+    call: ""
+    # -- Render the notification body as Markdown. Empty = upstream default (true).
+    markdown: ""
+    # -- Label for the action button that opens the alert's generator/Prometheus
+    # URL. Only effective when alertMode is "single". Example: "View".
+    generatorUrlLabel: ""
+    # -- Absolute path inside the pod to a Go text/template file that overrides
+    # the default notification body. When `template.enabled` is true and this
+    # is left empty, it auto-fills to /etc/ntfy-alertmanager/template.tmpl.
+    templatePath: ""
+
+  # Optional rendering template for the notification body. When enabled,
+  # a ConfigMap is created and mounted at /etc/ntfy-alertmanager/template.tmpl
+  # and ntfy.templatePath is auto-set to point at it.
+  template:
+    # -- Render the template ConfigMap and mount it into the pod.
+    enabled: false
+    # -- Go text/template source. See xenrox/ntfy-alertmanager docs for the
+    # available `.Alerts[]`, `.CommonLabels`, `.CommonAnnotations`, etc.
+    body: ""
+
+  # Label-driven priority/tag/icon/topic mapping. `order` defines the
+  # decreasing priority of label lookups; entries map specific label=value
+  # pairs to ntfy attributes.
+  labels:
+    # -- Decreasing-priority list of label names to consult.
+    order:
+      - severity
+      - instance
+    # -- Per-label mapping entries. Each entry takes `label`, `value`, and
+    # any of: `priority`, `tags` (list), `icon`, `emailAddress`, `call`, `topic`.
+    entries:
+      - label: severity
+        value: critical
+        priority: 5
+        tags:
+          - "rotating_light"
+      - label: severity
+        value: info
+        priority: 1
+
+  # Settings applied to "resolved" notifications. Take precedence over the
+  # entries in `labels.entries` for matching alerts.
+  resolved:
+    # -- Update the original ntfy notification instead of pushing a new one
+    # when an alert resolves. Halves the notification count in practice.
+    updateNotification: false
+    # -- Tags appended to resolved-alert notifications.
+    tags:
+      - "white_check_mark"
+    # -- ntfy priority for resolved-alert notifications.
+    priority: ""
+    # -- Icon URL for resolved-alert notifications.
+    icon: ""
+
+  # Alertmanager integration (silence-button proxy). When silenceDuration is
+  # set and baseURL is configured, ntfy notifications include a "Silence"
+  # action button that round-trips through this bridge to the Alertmanager API.
+  alertmanager:
+    # -- How long a silence created from the notification lasts (e.g. "24h").
+    silenceDuration: ""
+    # -- Alertmanager basic-auth user when the API is protected.
+    user: ""
+    # -- Alertmanager basic-auth password.
+    password: ""
+    # -- Override the Alertmanager URL parsed from the webhook payload.
+    url: ""
+
+  # Cache to deduplicate recurring alerts when alertMode is "single".
+  cache:
+    # -- Cache backend (disabled, memory, redis).
+    type: ""
+    # -- How long entries stay in the cache.
+    duration: ""
+    # -- Memory cache cleanup interval.
+    cleanupInterval: ""
+    # -- Redis URL (only used when type is redis).
+    redisURL: ""
+
+# -- Image pull secrets.
+imagePullSecrets: []
+# -- Override the chart name used in resource names.
+nameOverride: ""
+# -- Override the fully qualified app name.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a service account for the bridge.
+  create: true
+  # -- Service account annotations.
+  annotations: {}
+  # -- Pre-existing service account name. Generated if empty and create is true.
+  name: ""
+
+# -- Extra labels added to every Pod.
+podLabels: {}
+# -- Extra annotations added to every Pod.
+podAnnotations: {}
+
+# -- Pod-level securityContext.
+podSecurityContext: {}
+# -- Container-level securityContext.
+securityContext: {}
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port.
+  port: 80
+
+ingress:
+  # -- Expose the bridge through an Ingress (needed for the Silence button).
+  enabled: false
+  # -- IngressClass name.
+  className: ""
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress hosts/paths.
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  # -- Ingress TLS configuration.
+  tls: []
+
+# -- Container resources.
+resources: {}
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
+  enabled: false
+  # -- Minimum replicas under autoscaling.
+  minReplicas: 1
+  # -- Maximum replicas under autoscaling.
+  maxReplicas: 5
+  # -- Target CPU utilization percentage.
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage.
+  targetMemoryUtilizationPercentage: ""
+
+# -- Node selector for pod scheduling.
+nodeSelector: {}
+# -- Tolerations for pod scheduling.
+tolerations: []
+# -- Affinity rules for pod scheduling.
+affinity: {}


### PR DESCRIPTION
## Summary

- Fork of the upstream `xenrox/ntfy-alertmanager` Helm chart (`contrib/charts/alertmanager-ntfy/`, AGPL-3.0), extended to render the full set of [scfg config options](https://codeberg.org/xenrox/ntfy-alertmanager/src/branch/master/config.scfg) the binary supports — `alert-mode`, `ntfy.template-path`, `ntfy.generator-url-label`, `resolved.update-notification`, the `alertmanager{}` silence-button block, and the `cache{}` block. Upstream only renders a small whitelist; this fork unlocks those knobs as plain values so consumers can tune notification verbosity without post-render kubectl patches.
- Optional `ntfyAlertmanager.template.enabled` + `body` writes a Go text/template into the config Secret as a second `template.tmpl` key, mounts it alongside the scfg, and auto-sets `template-path` — useful for replacing the bridge's default label+annotation dump with a user-friendly Markdown body.
- `appVersion: "1.0.0"` so the image tag defaults track the current binary release; deployment uses `/health` probes (no probe-bug workaround needed).
- AGPL-3.0 license bundled at `charts/alertmanager-ntfy/LICENSE` with a `NOTICE` documenting fork origin and changes. The repo-level MIT LICENSE is untouched — only this chart subtree is AGPL.

## Test plan

- [x] `helm lint charts/alertmanager-ntfy/` clean
- [x] `helm template` with default values renders an scfg byte-equivalent in shape to the upstream chart's output
- [x] `helm template` with `alertMode: single` + `template.enabled` + `generatorUrlLabel` + `resolved.updateNotification: true` emits all four knobs
- [x] Edge cases verified: `markdown: false` now emits (was silently dropped via `with`); `template.enabled` with empty `body` emits neither `template-path` nor `template.tmpl`; `password` without `user` does not emit a stray `user` line; empty `topic` does not emit a broken line
- [x] `helm-docs` regenerates `README.md` cleanly
- [ ] chart-testing `ct lint` + `ct install` in CI (KinD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)