### PR TITLE
valheim-server: fix BepInEx modding + harden chart (v1.2.0)

### DIFF
--- a/charts/valheim-server/Chart.yaml
+++ b/charts/valheim-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valheim-server
 description: A Helm chart for deploying a Valheim dedicated server on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "3.1.0"
 home: https://www.valheimgame.com/
 icon: https://cdn2.steamgriddb.com/icon/d17892563a6984845a0e23df7841f903/32/256x256.png

--- a/charts/valheim-server/README.md
+++ b/charts/valheim-server/README.md
@@ -1,6 +1,6 @@
 # valheim-server
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 A Helm chart for deploying a Valheim dedicated server on Kubernetes
 
@@ -127,6 +127,8 @@ kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 | automation.autoBackupSchedule | string | `"*/15 * * * *"` | Cron schedule for automatic backups |
 | automation.autoUpdate | int | `1` | Enable automatic updates (1=enabled, 0=disabled) |
 | automation.autoUpdateSchedule | string | `"0 1 * * *"` | Cron schedule for automatic updates |
+| automation.scheduledRestart | int | `0` | Enable a scheduled server restart (1=enabled, 0=disabled) |
+| automation.scheduledRestartSchedule | string | `"0 2 * * *"` | Cron schedule for the scheduled restart |
 | automation.updateOnStartup | int | `0` | Update server when container starts (1=enabled, 0=disabled) |
 | extraEnv | list | `[]` | Additional environment variables for the Valheim server |
 | fullnameOverride | string | `""` | Provide a full name override for resources |
@@ -143,9 +145,8 @@ kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 | livenessProbe.initialDelaySeconds | int | `60` | Initial delay seconds |
 | livenessProbe.periodSeconds | int | `20` | Period seconds |
 | livenessProbe.timeoutSeconds | int | `5` | Timeout seconds |
-| modding.bepInEx | int | `0` | Enable BepInEx for mods (1=enabled, 0=disabled) |
-| modding.modPath | string | `"/home/steam/valheim/BepInEx"` | Path to mounted mod directory |
-| modding.useConfigurationManager | bool | `false` | Enable mounting a ConfigurationManager config |
+| modding.bepInEx | int | `0` | Enable BepInEx mod loader (1=enabled, 0=disabled). When enabled, sets the container's TYPE=BepInEx. Mods and their config live in the persistent server PVC under BepInEx/, so they survive pod restarts. |
+| modding.mods | list | `[]` | List of mods for the container to download on startup (requires bepInEx=1). Each entry is a Thunderstore dependency string (Author-Package-Version) or a direct URL. Supported files: zip, dll, cfg. |
 | nameOverride | string | `""` | Provide a name override for resources |
 | nodeSelector | object | `{}` | Node selector for pod assignment |
 | notifications.includePublicIp | int | `0` | Include the server's public IP in notifications (1=enabled, 0=disabled) |
@@ -172,10 +173,14 @@ kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 | securityContext.runAsGroup | int | `1000` | Group ID to run the container processes |
 | securityContext.runAsNonRoot | bool | `true` | Force the container to run as a non-root user |
 | securityContext.runAsUser | int | `111` | User ID to run the container processes. Should default to the steam user ID. |
+| server.crossplay | int | `0` | Enable crossplay/PlayFab networking (1=enabled, 0=disabled). NOTE: crossplay is mutually exclusive with BepInEx mods — with crossplay on, mods will not load. |
+| server.modifiers | string | `""` | World modifiers as space-separated "key value" pairs (e.g. "combat veryhard portals casual"). Leave empty to skip. |
 | server.name | string | `"Valheim Server with Helm"` | Server name as displayed in-game |
 | server.password | string | you MUST change this value | Server access password (minimum 5 characters) |
 | server.port | int | `2456` | UDP port for game server (will use PORT, PORT+1, and PORT+2) |
+| server.preset | string | `""` | World preset (e.g. Normal, Casual, Hard, Hardcore, Immersive, Hammer). Leave empty to skip. |
 | server.public | int | `0` | Set to 1 to make server visible publicly, 0 for private |
+| server.setKey | string | `""` | Global keys to set (e.g. "nobuildcost,nomap"). Leave empty to skip. |
 | server.timezone | string | `"UTC"` | Timezone for the server |
 | server.world | string | `"Dedicated"` | World name used for save files |
 | service.annotations | object | `{}` | Annotations for the service |
@@ -190,6 +195,7 @@ kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 | startupProbe.initialDelaySeconds | int | `30` | Initial delay seconds |
 | startupProbe.periodSeconds | int | `10` | Period seconds |
 | startupProbe.timeoutSeconds | int | `5` | Timeout seconds |
+| terminationGracePeriodSeconds | int | `120` | Grace period (seconds) for the pod to shut down. Gives the server time to save the world and run an optional shutdown backup before being force-killed. |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 
 ----------------------------------------------

--- a/charts/valheim-server/README.md
+++ b/charts/valheim-server/README.md
@@ -114,6 +114,28 @@ Note: This will not delete the Persistent Volume Claims. To delete them:
 kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 ```
 
+## Troubleshooting
+
+### `Failed to install app '896660' (Missing configuration)` on first boot
+
+On a brand-new deployment the container may log a SteamCMD error like
+`Failed to install app '896660' (Missing configuration)` and the pod may restart once or
+twice before the server comes up. This is a known, transient SteamCMD behaviour (it
+self-updates and restarts on the first run, completing the app install on a subsequent
+attempt) — it is not specific to this chart and also happens with plain `docker run` of the
+upstream image. The pod recovers on its own; with persistence enabled the already-downloaded
+server files are reused, so later restarts skip the install entirely. If it does not recover,
+check that the `server` PVC has enough free space (the game needs a few GB).
+
+## Modding (BepInEx)
+
+Set `modding.bepInEx: 1` to start the server with `TYPE=BepInEx`, and list mods in
+`modding.mods` (Thunderstore `Author-Package-Version` strings or direct URLs). Mods and their
+configuration are stored under `BepInEx/` inside the persistent `server` PVC, so they survive
+pod restarts. Note: BepInEx mods are **mutually exclusive with crossplay** — with
+`server.crossplay: 1`, Valheim uses PlayFab networking, which BepInEx cannot hook, so mods
+will not load.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/valheim-server/README.md.gotmpl
+++ b/charts/valheim-server/README.md.gotmpl
@@ -108,6 +108,28 @@ Note: This will not delete the Persistent Volume Claims. To delete them:
 kubectl delete pvc -l app.kubernetes.io/instance=my-valheim-server
 ```
 
+## Troubleshooting
+
+### `Failed to install app '896660' (Missing configuration)` on first boot
+
+On a brand-new deployment the container may log a SteamCMD error like
+`Failed to install app '896660' (Missing configuration)` and the pod may restart once or
+twice before the server comes up. This is a known, transient SteamCMD behaviour (it
+self-updates and restarts on the first run, completing the app install on a subsequent
+attempt) — it is not specific to this chart and also happens with plain `docker run` of the
+upstream image. The pod recovers on its own; with persistence enabled the already-downloaded
+server files are reused, so later restarts skip the install entirely. If it does not recover,
+check that the `server` PVC has enough free space (the game needs a few GB).
+
+## Modding (BepInEx)
+
+Set `modding.bepInEx: 1` to start the server with `TYPE=BepInEx`, and list mods in
+`modding.mods` (Thunderstore `Author-Package-Version` strings or direct URLs). Mods and their
+configuration are stored under `BepInEx/` inside the persistent `server` PVC, so they survive
+pod restarts. Note: BepInEx mods are **mutually exclusive with crossplay** — with
+`server.crossplay: 1`, Valheim uses PlayFab networking, which BepInEx cannot hook, so mods
+will not load.
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/valheim-server/templates/NOTES.txt
+++ b/charts/valheim-server/templates/NOTES.txt
@@ -31,6 +31,28 @@ Note: You've deployed with service type "{{ .Values.service.type }}" which may n
 You might need to set up port forwarding or ingress to access your server.
 {{- end }}
 
+{{- if eq (.Values.modding.bepInEx | toString) "1" }}
+
+MODDING (BepInEx) is ENABLED:
+- The container starts with TYPE=BepInEx.
+{{- if .Values.modding.mods }}
+- The following mods will be downloaded on startup:
+  {{- range .Values.modding.mods }}
+  - {{ . }}
+  {{- end }}
+{{- else }}
+- No mods are listed in `modding.mods`; set that value to have the container download mods.
+{{- end }}
+- Mods and their config persist under BepInEx/ inside the server PVC across restarts.
+- Upstream recommends disabling `automation.autoUpdate` while modding to avoid breaking mods.
+{{- if eq (.Values.server.crossplay | toString) "1" }}
+
+WARNING: crossplay (server.crossplay=1) and BepInEx mods are MUTUALLY EXCLUSIVE.
+With crossplay on, Valheim uses PlayFab networking, which BepInEx cannot hook, so your
+mods will NOT load. For a modded server, set server.crossplay=0 (Steam-only players).
+{{- end }}
+{{- end }}
+
 IMPORTANT SECURITY NOTES:
 - Make sure your server password is at least 5 characters long
 - Properly secure access to your Kubernetes cluster

--- a/charts/valheim-server/templates/_helpers.tpl
+++ b/charts/valheim-server/templates/_helpers.tpl
@@ -49,3 +49,13 @@ Selector labels
 app.kubernetes.io/name: {{ include "valheim-server.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Returns a non-empty string when any backup feature is enabled (scheduled, on-update, or
+on-shutdown). Used to decide whether the backups PVC should be provisioned.
+*/}}
+{{- define "valheim-server.backupsEnabled" -}}
+{{- if or (eq (.Values.automation.autoBackup | toString) "1") (eq (.Values.automation.autoBackupOnUpdate | toString) "1") (eq (.Values.automation.autoBackupOnShutdown | toString) "1") -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/valheim-server/templates/deployment.yaml
+++ b/charts/valheim-server/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "valheim-server.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers.enabled }}
@@ -62,6 +64,20 @@ spec:
               value: "{{ .Values.securityContext.runAsGroup | default "1000" }}"
             - name: PUBLIC
               value: "{{ .Values.server.public }}"
+            - name: ENABLE_CROSSPLAY
+              value: "{{ .Values.server.crossplay }}"
+            {{- if .Values.server.preset }}
+            - name: PRESET
+              value: "{{ .Values.server.preset }}"
+            {{- end }}
+            {{- if .Values.server.modifiers }}
+            - name: MODIFIERS
+              value: "{{ .Values.server.modifiers }}"
+            {{- end }}
+            {{- if .Values.server.setKey }}
+            - name: SET_KEY
+              value: "{{ .Values.server.setKey }}"
+            {{- end }}
             - name: AUTO_UPDATE
               value: "{{ .Values.automation.autoUpdate }}"
             - name: AUTO_UPDATE_SCHEDULE
@@ -80,6 +96,10 @@ spec:
               value: "{{ .Values.automation.autoBackupOnUpdate }}"
             - name: AUTO_BACKUP_ON_SHUTDOWN
               value: "{{ .Values.automation.autoBackupOnShutdown }}"
+            - name: SCHEDULED_RESTART
+              value: "{{ .Values.automation.scheduledRestart }}"
+            - name: SCHEDULED_RESTART_SCHEDULE
+              value: "{{ .Values.automation.scheduledRestartSchedule }}"
             {{- if .Values.notifications.webhookUrl }}
             - name: WEBHOOK_URL
               value: "{{ .Values.notifications.webhookUrl }}"
@@ -87,8 +107,13 @@ spec:
               value: "{{ .Values.notifications.includePublicIp }}"
             {{- end }}
             {{- if eq (.Values.modding.bepInEx | toString) "1" }}
-            - name: BEPINEX
-              value: "1"
+            - name: TYPE
+              value: "BepInEx"
+            {{- if .Values.modding.mods }}
+            - name: MODS
+              value: |-
+{{ .Values.modding.mods | join "\n" | indent 16 }}
+            {{- end }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -114,10 +139,6 @@ spec:
               mountPath: /home/steam/valheim
             - name: backups
               mountPath: /home/steam/backups
-            {{- if eq (.Values.modding.bepInEx | toString) "1" }}
-            - name: mods
-              mountPath: {{ .Values.modding.modPath }}
-            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Startup probe - wait for server to initialize
@@ -184,16 +205,12 @@ spec:
           {{- if and .Values.persistence.enabled .Values.persistence.backups.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.backups.existingClaim }}
-          {{- else if .Values.persistence.enabled }}
+          {{- else if and .Values.persistence.enabled (include "valheim-server.backupsEnabled" .) }}
           persistentVolumeClaim:
             claimName: {{ include "valheim-server.fullname" . }}-backups
           {{- else }}
           emptyDir: {}
           {{- end }}
-        {{- if eq (.Values.modding.bepInEx | toString) "1" }}
-        - name: mods
-          emptyDir: {}
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/valheim-server/templates/pvc.yaml
+++ b/charts/valheim-server/templates/pvc.yaml
@@ -43,7 +43,7 @@ spec:
       storage: {{ .Values.persistence.server.size }}
 {{- end }}
 
-{{- if and .Values.persistence.enabled (not .Values.persistence.backups.existingClaim) }}
+{{- if and .Values.persistence.enabled (include "valheim-server.backupsEnabled" .) (not .Values.persistence.backups.existingClaim) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/valheim-server/values.yaml
+++ b/charts/valheim-server/values.yaml
@@ -10,6 +10,10 @@ image:
 # -- Number of replicas to deploy (should typically stay at 1)
 replicaCount: 1
 
+# -- Grace period (seconds) for the pod to shut down. Gives the server time to save the
+# world and run an optional shutdown backup before being force-killed.
+terminationGracePeriodSeconds: 120
+
 # -- Provide a name override for resources
 nameOverride: ""
 
@@ -31,6 +35,15 @@ server:
   public: 0
   # -- Timezone for the server
   timezone: "UTC"
+  # -- Enable crossplay/PlayFab networking (1=enabled, 0=disabled). NOTE: crossplay is
+  # mutually exclusive with BepInEx mods — with crossplay on, mods will not load.
+  crossplay: 0
+  # -- World preset (e.g. Normal, Casual, Hard, Hardcore, Immersive, Hammer). Leave empty to skip.
+  preset: ""
+  # -- World modifiers as space-separated "key value" pairs (e.g. "combat veryhard portals casual"). Leave empty to skip.
+  modifiers: ""
+  # -- Global keys to set (e.g. "nobuildcost,nomap"). Leave empty to skip.
+  setKey: ""
 
 # Automation configuration for the server
 automation:
@@ -52,6 +65,10 @@ automation:
   autoBackupOnUpdate: 1
   # -- Create backup on server shutdown (1=enabled, 0=disabled)
   autoBackupOnShutdown: 0
+  # -- Enable a scheduled server restart (1=enabled, 0=disabled)
+  scheduledRestart: 0
+  # -- Cron schedule for the scheduled restart
+  scheduledRestartSchedule: "0 2 * * *"
 
 # Notification settings for server events
 notifications:
@@ -106,7 +123,9 @@ persistence:
     # -- Existing claim to use (leave empty to create a new one)
     existingClaim: ""
 
-  # Data volume configuration for backups. Requires "autoBackup: 1".
+  # Data volume configuration for backups. The PVC is only provisioned when a backup feature
+  # is enabled (automation.autoBackup, autoBackupOnUpdate, or autoBackupOnShutdown = 1);
+  # otherwise the backups directory uses an ephemeral emptyDir.
   backups:
     # -- Size of PVC for backups
     size: 10Gi
@@ -159,12 +178,17 @@ initContainers:
 
 # Modding configuration
 modding:
-  # -- Enable BepInEx for mods (1=enabled, 0=disabled)
+  # -- Enable BepInEx mod loader (1=enabled, 0=disabled). When enabled, sets the
+  # container's TYPE=BepInEx. Mods and their config live in the persistent server
+  # PVC under BepInEx/, so they survive pod restarts.
   bepInEx: 0
-  # -- Path to mounted mod directory
-  modPath: "/home/steam/valheim/BepInEx"
-  # -- Enable mounting a ConfigurationManager config
-  useConfigurationManager: false
+  # -- List of mods for the container to download on startup (requires bepInEx=1).
+  # Each entry is a Thunderstore dependency string (Author-Package-Version) or a
+  # direct URL. Supported files: zip, dll, cfg.
+  mods: []
+    # - ZenDragon-Zen_ModLib-1.11.4
+    # - ZenDragon-ZenCompass-1.7.1
+    # - ZenDragon-ZenPortal-0.7.6
 
 # Pod security context settings
 # @descriptionStart


### PR DESCRIPTION
## Summary

Fixes broken BepInEx modding in `valheim-server` and folds in a full-chart audit hardening pass, verified against the upstream `mbround18/valheim-docker` image source and with live installs on a real cluster.

### Modding fix (the headline)
- The chart set `BEPINEX=1`, but the image has **no such variable** — it uses `TYPE=BepInEx`. Modding was a silent no-op. Now activated via `TYPE`.
- Added a first-class `modding.mods` list wired to the image's `MODS` env (Thunderstore `Author-Package-Version` strings or URLs).
- **Removed the `mods` emptyDir** that was mounted over `/home/steam/valheim/BepInEx`, shadowing it with ephemeral storage. With it gone, BepInEx plugins **and config** live in the persistent `server` PVC and survive restarts — solving the original mod-config persistence problem.

### Full-chart audit hardening
- `automountServiceAccountToken: false` (repo convention) + configurable `terminationGracePeriodSeconds` (120) for clean world-save/shutdown-backup.
- Backups PVC provisioned **only** when a backup feature is enabled (`autoBackup` / `autoBackupOnUpdate` / `autoBackupOnShutdown`) via a new `backupsEnabled` helper; otherwise ephemeral `emptyDir`.
- First-class values for `server.crossplay` / `preset` / `modifiers` / `setKey` and `automation.scheduledRestart(+Schedule)`.
- NOTES warning: crossplay and BepInEx mods are **mutually exclusive** (crossplay uses PlayFab networking, which BepInEx can't hook).
- README Troubleshooting note for the transient SteamCMD `Missing configuration` first-boot flake (upstream behavior, self-recovers).

Chart bumped to **1.2.0**; README regenerated.

## Verification
- `helm lint`, `ct lint`, and **15/15** real-world config renders pass; targeted assertions confirm SA-token removal, grace period, crossplay/scheduled-restart env, conditional preset/modifiers, and backups PVC gating (2 PVCs when all backups off, 3 by default).
- **Live (mbround18/valheim:3.1.0):**
  - *Modded:* `Found Type BepInEx` → Jotunn installed → **config marker + plugin survived a full pod replacement**.
  - *Crossplay:* `ENABLE_CROSSPLAY=1`/`PUBLIC=1` confirmed in-container; SA token mount absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)