### PR TITLE
chore(palworld-server): bump appVersion to v2.5.0 (chart 1.2.1)

### DIFF
--- a/charts/palworld-server/Chart.yaml
+++ b/charts/palworld-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: palworld-server
 description: This Helm chart deploys a Palworld dedicated game server on a Kubernetes cluster.
 type: application
-version: 1.2.0
-appVersion: "v2.3.0"
+version: 1.2.1
+appVersion: "v2.5.0"
 home: https://www.pocketpair.jp/palworld
 icon: https://cdn2.steamgriddb.com/icon/82cf0712367108660c5339a4897a728e/32/128x128.png
 keywords:
@@ -26,4 +26,4 @@ annotations:
       url: https://github.com/thijsvanloef/palworld-server-docker
   artifacthub.io/images: |
     - name: palworld-server-docker
-      image: thijsvanloef/palworld-server-docker:v2.3.0
+      image: thijsvanloef/palworld-server-docker:v2.5.0

--- a/charts/palworld-server/README.md
+++ b/charts/palworld-server/README.md
@@ -1,6 +1,6 @@
 # Palworld Server Helm Chart
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=flat-square)
 
 This Helm chart deploys a Palworld dedicated game server on a Kubernetes cluster.
 


### PR DESCRIPTION
## Summary
- Bump `palworld-server` chart to **1.2.1**, appVersion **v2.3.0 → v2.5.0** (Palworld 1.0 launch image)
- Update `artifacthub.io/images` annotation and regenerate README via helm-docs

## Upstream review (thijsvanloef/palworld-server-docker v2.3.0 → v2.5.0)
- No changes to ports (8211/8212/27015/25575), `/palworld` volume, entrypoint, or PUID/PGID non-root model — no template changes required
- Only new env vars are optional (`LOG_FORMAT_TYPE`, `LOG_FILTER_ENABLED`), covered by existing `extraEnv` passthrough
- Palworld 1.0 changed several in-game setting defaults (death penalty, egg hatch time, player-list visibility); handled generically by the container's settings compiler, no chart plumbing needed

`helm lint` passes.